### PR TITLE
Set the Navbar Logo height in CSS

### DIFF
--- a/src/main/java/io/skymind/pathmind/ui/layouts/components/SectionsHeaderPanel.java
+++ b/src/main/java/io/skymind/pathmind/ui/layouts/components/SectionsHeaderPanel.java
@@ -13,7 +13,7 @@ public class SectionsHeaderPanel extends HorizontalLayout
 	{
 		HorizontalLayout sectionsHorizontalLayout = new HorizontalLayout();
 		final Image logo = new Image("frontend/images/pathmind-logo.png", "Skymind Logo");
-		logo.getStyle().set("width", "9em");
+		logo.addClassName("navbar-logo");
 		sectionsHorizontalLayout.add(
 				logo,
 				new RouterLink("Dashboard", DashboardView.class),

--- a/src/main/resources/META-INF/resources/frontend/styles/styles.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/styles.css
@@ -3,6 +3,11 @@
     line-height: 31px;
 }
 
+.navbar-logo {
+    width: 144px;
+    height: 31px;
+}
+
 .section-label-title {
     font-size: 22px;
     font-weight: bold;


### PR DESCRIPTION
I set the height and width using the style.css class. I only tested this in Fx on OSX which did not show the bug, but also did not regress with this change.

Fixes #77