### PR TITLE
Simplify the training runs

### DIFF
--- a/src/main/java/io/skymind/pathmind/services/TrainingService.java
+++ b/src/main/java/io/skymind/pathmind/services/TrainingService.java
@@ -78,11 +78,11 @@ public class TrainingService {
     }
 
     public void startDiscoveryRun(Experiment exp){
-        startDiscoveryRunHelper1(exp);
-        startDiscoveryRunHelper2(exp);
+        startDiscoveryRunJob1(exp);
+        startDiscoveryRunJob2(exp);
     }
 
-    public void startDiscoveryRunHelper1(Experiment exp){
+    public void startDiscoveryRunJob1(Experiment exp){
         final Run run = runDAO.createRun(exp, RunType.DiscoveryRun);
         // Get model from the database, as the one we can get from the experiment doesn't have all fields
         final Model model = modelDAO.getModel(exp.getModelId());
@@ -113,7 +113,7 @@ public class TrainingService {
         log.info("Started DISCOVERY training job with id {}", executionId);
     }
 
-    public void startDiscoveryRunHelper2(Experiment exp){
+    public void startDiscoveryRunJob2(Experiment exp){
         final Run run = runDAO.createRun(exp, RunType.DiscoveryRun);
         // Get model from the database, as the one we can get from the experiment doesn't have all fields
         final Model model = modelDAO.getModel(exp.getModelId());


### PR DESCRIPTION
We're simplifying the training runs so that users get feedback more quickly.

- Discovery runs explore 8 different settings and run 100 iterations and run in two separate jobs. (It works but is done in a very basic way. Don't laugh)
- Full runs remain at 500 iterations.

Look, two discovery run policies are training at the same time. The test run is still going there too.
<img width="1429" alt="Screen Shot 2019-10-09 at 10 51 09 PM" src="https://user-images.githubusercontent.com/1197406/66542546-bd8d2680-eae7-11e9-92e8-c4f48d00fbef.png">


