### PR TITLE
Dev-450 - Temporary solution so that runs show completed when they are completed

### DIFF
--- a/src/main/java/io/skymind/pathmind/bus/BusEventType.java
+++ b/src/main/java/io/skymind/pathmind/bus/BusEventType.java
@@ -3,5 +3,6 @@ package io.skymind.pathmind.bus;
 public enum BusEventType
 {
 	PolicyUpdate,
+	RunUpdate,
 	UserUpdate
 }

--- a/src/main/java/io/skymind/pathmind/bus/events/RunUpdateBusEvent.java
+++ b/src/main/java/io/skymind/pathmind/bus/events/RunUpdateBusEvent.java
@@ -1,0 +1,36 @@
+package io.skymind.pathmind.bus.events;
+
+import io.skymind.pathmind.bus.BusEventType;
+import io.skymind.pathmind.bus.PathmindBusEvent;
+import io.skymind.pathmind.data.Policy;
+import io.skymind.pathmind.data.Run;
+
+public class RunUpdateBusEvent implements PathmindBusEvent
+{
+	private Run run;
+
+	public RunUpdateBusEvent(Run run)
+	{
+		if(run.getExperiment() == null)
+			throw new RuntimeException("Experiment is null");
+		if(run.getModel() == null)
+			throw new RuntimeException("Model is null");
+		if(run.getProject() == null)
+			throw new RuntimeException("Project is null");
+
+		this.run = run;
+	}
+
+	@Override
+	public BusEventType getEventType() {
+		return BusEventType.RunUpdate;
+	}
+
+	public Run getRun() {
+		return run;
+	}
+
+	public void setRun(Run run) {
+		this.run = run;
+	}
+}

--- a/src/main/java/io/skymind/pathmind/bus/subscribers/RunUpdateSubscriber.java
+++ b/src/main/java/io/skymind/pathmind/bus/subscribers/RunUpdateSubscriber.java
@@ -1,0 +1,13 @@
+package io.skymind.pathmind.bus.subscribers;
+
+import io.skymind.pathmind.bus.BusEventType;
+import io.skymind.pathmind.bus.EventBusSubscriber;
+import io.skymind.pathmind.bus.events.RunUpdateBusEvent;
+
+public interface RunUpdateSubscriber extends EventBusSubscriber<RunUpdateBusEvent>
+{
+    @Override
+    default BusEventType getEventType() {
+        return BusEventType.RunUpdate;
+    }
+}

--- a/src/main/java/io/skymind/pathmind/ui/views/experiment/components/TrainingsListPanel.java
+++ b/src/main/java/io/skymind/pathmind/ui/views/experiment/components/TrainingsListPanel.java
@@ -1,11 +1,8 @@
 package io.skymind.pathmind.ui.views.experiment.components;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.function.Consumer;
-
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridSingleSelectionModel;
@@ -15,27 +12,41 @@ import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.spring.annotation.SpringComponent;
 import com.vaadin.flow.spring.annotation.UIScope;
-
 import io.skymind.pathmind.bus.EventBus;
 import io.skymind.pathmind.bus.events.PolicyUpdateBusEvent;
+import io.skymind.pathmind.bus.events.RunUpdateBusEvent;
 import io.skymind.pathmind.bus.subscribers.PolicyUpdateSubscriber;
+import io.skymind.pathmind.bus.subscribers.RunUpdateSubscriber;
 import io.skymind.pathmind.data.Experiment;
 import io.skymind.pathmind.data.Policy;
+import io.skymind.pathmind.data.Run;
 import io.skymind.pathmind.data.utils.PolicyUtils;
 import io.skymind.pathmind.ui.renderer.ZonedDateTimeRenderer;
 import io.skymind.pathmind.ui.utils.PushUtils;
 import io.skymind.pathmind.utils.DateAndTimeUtils;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Consumer;
+
 @SpringComponent
 @UIScope
-public class TrainingsListPanel extends VerticalLayout implements PolicyUpdateSubscriber {
+public class TrainingsListPanel extends VerticalLayout
+{
     private Grid<Policy> grid;
 
     private Experiment experiment;
 
+    private TrainingListPolicyUpdateSubscriber policyUpdateSubscriber;
+    private TrainingListRunUpdateSubscriber runUpdateSubscriber;
+
     public TrainingsListPanel() {
         setupGrid();
         add(grid);
+
+        policyUpdateSubscriber = new TrainingListPolicyUpdateSubscriber();
+        runUpdateSubscriber = new TrainingListRunUpdateSubscriber();
 
         // Always force at least one item to be selected.
         ((GridSingleSelectionModel<Policy>) grid.getSelectionModel()).setDeselectAllowed(false);
@@ -66,7 +77,7 @@ public class TrainingsListPanel extends VerticalLayout implements PolicyUpdateSu
                 .setSortable(true);
 
         Grid.Column<Policy> scoreColumn = grid.addColumn(policy -> PolicyUtils.getFormattedLastScore(policy))
-        		.setComparator(Comparator.comparing(policy -> PolicyUtils.getLastScore(policy), Comparator.nullsLast(Comparator.naturalOrder())))
+                .setComparator(Comparator.comparing(policy -> PolicyUtils.getLastScore(policy), Comparator.nullsLast(Comparator.naturalOrder())))
                 .setHeader("Score")
                 .setAutoWidth(true)
                 .setTextAlign(ColumnTextAlign.END)
@@ -106,8 +117,19 @@ public class TrainingsListPanel extends VerticalLayout implements PolicyUpdateSu
                 selectionPolicy.getFirstSelectedItem().ifPresent(p -> consumer.accept(p)));
     }
 
+    private void updatedRunForPoliciesInGrid(Run run) {
+        experiment.getPolicies().stream()
+                .filter(policy -> policy.getRunId() == run.getId())
+                .forEach(policy -> {
+                    policy.setRun(run);
+                    grid.getDataProvider().refreshItem(policy);
+                });
+        // BUG -> If you search/filter after an update the grid uses the old value in the row.
+        // TODO -> Re-select same policy
+        // TODO -> refilter according to the search box.
+    }
 
-    private void updatedGrid(Policy updatedPolicy) {
+    private void updatePolicyInGrid(Policy updatedPolicy) {
         experiment.getPolicies().stream()
                 .filter(policy -> policy.getId() == updatedPolicy.getId())
                 .findAny()
@@ -146,7 +168,7 @@ public class TrainingsListPanel extends VerticalLayout implements PolicyUpdateSu
 
         DateAndTimeUtils.withUserTimeZoneId(timeZoneId -> {
             // grid uses ZonedDateTimeRenderer, making sure here that time zone id is loaded properly before setting items
-        	grid.setDataProvider(new ListDataProvider<>(experiment.getPolicies()));
+            grid.setDataProvider(new ListDataProvider<>(experiment.getPolicies()));
         });
 
         if (!experiment.getPolicies().isEmpty() && defaultSelectedPolicyId < 0) {
@@ -161,28 +183,56 @@ public class TrainingsListPanel extends VerticalLayout implements PolicyUpdateSu
 
     @Override
     protected void onDetach(DetachEvent event) {
-        EventBus.unsubscribe(this);
+        EventBus.unsubscribe(policyUpdateSubscriber);
+        EventBus.unsubscribe(runUpdateSubscriber);
     }
 
     @Override
     protected void onAttach(AttachEvent event) {
-        EventBus.subscribe(this);
-    }
-
-    @Override
-    public void handleBusEvent(PolicyUpdateBusEvent event) {
-        PushUtils.push(this, () -> updatedGrid(event.getPolicy()));
-    }
-
-    @Override
-    public boolean filterBusEvent(PolicyUpdateBusEvent event) {
-        return experiment.getId() == event.getPolicy().getExperiment().getId();
+        EventBus.subscribe(policyUpdateSubscriber);
+        EventBus.subscribe(runUpdateSubscriber);
     }
 
     public void selectPolicyWithId(String policyId) {
-    	experiment.getPolicies().stream()
-        	.filter(policy -> Long.toString(policy.getId()).equals(policyId))
-        	.findAny()
-        	.ifPresent(policy -> grid.select(policy));
+        experiment.getPolicies().stream()
+                .filter(policy -> Long.toString(policy.getId()).equals(policyId))
+                .findAny()
+                .ifPresent(policy -> grid.select(policy));
+    }
+
+    class TrainingListPolicyUpdateSubscriber implements PolicyUpdateSubscriber
+    {
+        @Override
+        public void handleBusEvent(PolicyUpdateBusEvent event) {
+            PushUtils.push(getUI(), () -> updatePolicyInGrid(event.getPolicy()));
+        }
+
+        @Override
+        public boolean filterBusEvent(PolicyUpdateBusEvent event) {
+            return experiment.getId() == event.getPolicy().getExperiment().getId();
+        }
+
+        @Override
+        public Optional<UI> getUI() {
+            return TrainingsListPanel.this.getUI();
+        }
+    }
+
+    class TrainingListRunUpdateSubscriber implements RunUpdateSubscriber
+    {
+        @Override
+        public boolean filterBusEvent(RunUpdateBusEvent event) {
+            return experiment.getId() == event.getRun().getExperiment().getId();
+        }
+
+        @Override
+        public void handleBusEvent(RunUpdateBusEvent event) {
+            PushUtils.push(getUI(), () -> updatedRunForPoliciesInGrid(event.getRun()));
+        }
+
+        @Override
+        public Optional<UI> getUI() {
+            return TrainingsListPanel.this.getUI();
+        }
     }
 }


### PR DESCRIPTION
Currently the API's do not have any policies when the run is completed and so the policies are not updated. As a temporary solution I added a RunUpdateBusEvent which is fired when the Run is completed and that the TrainingListPanel listens to for updates. Should a RunUpdateBusEvent occur TrainingListPanels refreshes the run for all the related policies and re-renders them.

I believe it's worth pushing through as a workaround solution because I personally find it very frustrating not knowing when a run is actually completed. I generally have to have a second tabbed panel open that I will F5 on to get the proper status.