### PR TITLE
#611 - Added the Versions Maven plugin to help keep track of dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,11 @@
                     </generator>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
It's a great plugin to let us know if we're up to date with all our dependencies: https://www.mojohaus.org/versions-maven-plugin/

I started to think we must be behind on several dependencies, which will include everything from bug fixes to security updates. This will help us determine what needs to be updated.