### PR TITLE
Fixes client-side error that prevents styles to be loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,22 +1126,6 @@
         "@vaadin/vaadin-upload": "4.2.2"
       },
       "dependencies": {
-        "@vaadin/vaadin-context-menu": {
-          "version": "4.3.15",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-4.3.15.tgz",
-          "integrity": "sha512-aXyBfFOiLlOTpuaMyIfb0MCWTqb4TUEhWQQi60TQbOlT8rIS/f+OymooME47tp8lVRwH/L2EOokhLTxZ37E1kw==",
-          "requires": {
-            "@polymer/iron-media-query": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-element-mixin": "^2.1.1",
-            "@vaadin/vaadin-item": "^2.1.0",
-            "@vaadin/vaadin-list-box": "^1.1.0",
-            "@vaadin/vaadin-lumo-styles": "^1.1.1",
-            "@vaadin/vaadin-material-styles": "^1.1.1",
-            "@vaadin/vaadin-overlay": "^3.2.9",
-            "@vaadin/vaadin-themable-mixin": "^1.3.2"
-          }
-        },
         "@vaadin/vaadin-core-shrinkwrap": {
           "version": "14.1.3",
           "resolved": "https://registry.npmjs.org/@vaadin/vaadin-core-shrinkwrap/-/vaadin-core-shrinkwrap-14.1.3.tgz",


### PR DESCRIPTION
In `package-lock.json` file, `@vaadin/vaadin-context-menu` is imported twice, this causes an error in client-side, and as a result styles are not loaded properly.

Although, the issue is automatically fixed after running the server again with `mvn clean spring-boot:run` or running a production build `mvn clean package -Pproduction`, this change prevents the error happen the first time.

Closes #672 