### PR TITLE
handle #709 error message

### DIFF
--- a/src/main/java/io/skymind/pathmind/services/training/cloud/rescale/RescaleExecutionProvider.java
+++ b/src/main/java/io/skymind/pathmind/services/training/cloud/rescale/RescaleExecutionProvider.java
@@ -39,6 +39,7 @@ public class RescaleExecutionProvider implements ExecutionProvider {
         KNOWN_ERROR_MSGS.add("Fatal Python error: Segmentation fault");
         KNOWN_ERROR_MSGS.add("Worker crashed during call to train()");
         KNOWN_ERROR_MSGS.add("java.lang.ArrayIndexOutOfBoundsException");
+        KNOWN_ERROR_MSGS.add("NotADirectoryError: [Errno 20] Not a directory");
     }
 
     public RescaleExecutionProvider(RescaleRestApiClient client) {


### PR DESCRIPTION
related https://github.com/SkymindIO/pathmind-webapp/issues/709

this is only for handling error messages for rescale.
as of now, even though it has error(NotADirectoryError: [Errno 20] Not a directory: 'database/db.properties') we cannot classify it as an error.

i will merge https://github.com/SkymindIO/pathmind-webapp/pull/714 after proper testing.

