### PR TITLE
Dev-692 - Drop progress column from policy table

### DIFF
--- a/src/main/resources/db/changelog/db.initial.xml
+++ b/src/main/resources/db/changelog/db.initial.xml
@@ -695,4 +695,8 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="20200127-01" author="steph@followsteph.com">
+        <dropColumn tableName="POLICY" columnName="PROGRESS"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
**UPDATE -> This is now part of #761 and will be in that PR.**

**IMPORTANT ->** Should be done after #446 has also been merged.

Now that the progress column has been pulled out of the policy table for a while we can comfortably delete it. This will have a slight performance improvement and reclaim space.

**IMPORTANT ->** @kepricon @slinlee Whoever pushes this to production can you also please run `VACUUM FULL;` in the database _AFTER pushing this and #446 into dev and production_. This will reclaim all the space used in the database by the binary and progress columns. It does lock the table for a few seconds (we still don't have that much data) but it should nonetheless be done outside of business hours.