### PR TITLE
Resolves #770 - Create indexes on foreign keys as they are often used in joins/where clauses

### DIFF
--- a/src/main/resources/db/changelog/db.initial.xml
+++ b/src/main/resources/db/changelog/db.initial.xml
@@ -757,4 +757,22 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="20200202-01" author="steph@followsteph.com">
+        <createIndex tableName="PROJECT" indexName="PROJECT_PATHMIND_USER_FK_INDEX">
+            <column name="PATHMIND_USER_ID"/>
+        </createIndex>
+        <createIndex tableName="MODEL" indexName="MODEL_PROJECT_FK_INDEX">
+            <column name="PROJECT_ID"/>
+        </createIndex>
+        <createIndex tableName="EXPERIMENT" indexName="EXPERIMENT_MODEL_FK_INDEX">
+            <column name="MODEL_ID"/>
+        </createIndex>
+        <createIndex tableName="RUN" indexName="RUN_EXPERIMENT_FK_INDEX">
+            <column name="EXPERIMENT_ID"/>
+        </createIndex>
+        <createIndex tableName="POLICY" indexName="POLICY_RUN_FK_INDEX">
+            <column name="RUN_ID"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
It's a very small and simple change but it should have a slight performance improvement in production. Please the more users and data we add the bigger the improvements.

I would recommend slipping this in with the database performance PR for Monday if possible. It costs about half a minute on the production database, so it would be nice to add to the upcoming update since we're already expecting some downtime.