### PR TITLE
Change 'Starting' to 'Starting Cluster' in run status enum (#743)

### DIFF
--- a/src/main/java/io/skymind/pathmind/constants/RunStatus.java
+++ b/src/main/java/io/skymind/pathmind/constants/RunStatus.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 public enum RunStatus
 {
 	NotStarted(0, "Not Started"),
-	Starting(1, "Starting"),
+	Starting(1, "Starting Cluster"),
 	Running(2, "Running"),
 	Completed(3, "Completed"),
 	Error(4, "Error"),


### PR DESCRIPTION
#### Change
- [x] Change text for the Starting run status enum from "Starting" to "Starting Cluster"

#### PR Screenshots
**Experiments (Model) Page**
![image](https://user-images.githubusercontent.com/13184582/74306303-28ec4b00-4d9d-11ea-9394-6b912b661499.png)

**Experiment Page**
![image](https://user-images.githubusercontent.com/13184582/74306250-01957e00-4d9d-11ea-8334-a3c598e9811d.png)

Closes #743