### PR TITLE
Enable reward function validation again

### DIFF
--- a/src/main/java/io/skymind/pathmind/services/RewardValidationService.java
+++ b/src/main/java/io/skymind/pathmind/services/RewardValidationService.java
@@ -8,10 +8,7 @@ import java.util.*;
 public class RewardValidationService {
 
     public static List<String> validateRewardFunction(String rewardFunction){
-        return Collections.emptyList();
-        //TODO: This fails on azure for some reason, missing JDK?
-
-        /*final String code = fillInTemplate(rewardFunction);
+        final String code = fillInTemplate(rewardFunction);
         final String[] lines = code.split("\n");
         int startReward = 0;
         int endReward = 0;
@@ -33,7 +30,7 @@ public class RewardValidationService {
             }
         }
 
-        return errors;*/
+        return errors;
     }
 
     private static String fillInTemplate(String rewardFunction){


### PR DESCRIPTION
This just reverts #545 to enable reward function validation again now that our docker image on AWS supports it.

Resolves #742 