### PR TITLE
#852 Fix inconsistent placement of Models/Archives tabs

### DIFF
--- a/frontend/styles/styles.css
+++ b/frontend/styles/styles.css
@@ -187,20 +187,16 @@ img {
   align-self: center;
 }
 
-.projects-view .content {
+.projects-view .content,
+.models-view .content {
   flex: 1;
   max-width: 1200px;
   align-self: center;
 }
 
-.projects-view .view-section {
-  flex: 1;
-}
-
+.projects-view .view-section,
 .models-view .view-section {
   flex: 1;
-  max-width: 1200px;
-  align-self: center;
 }
 
 account-view {

--- a/src/main/java/io/skymind/pathmind/ui/views/model/ModelsView.java
+++ b/src/main/java/io/skymind/pathmind/ui/views/model/ModelsView.java
@@ -80,15 +80,18 @@ public class ModelsView extends PathMindDefaultView implements HasUrlParameter<L
 		// is why the table is centered vertically: https://github.com/vaadin/vaadin-app-layout/issues/51
 		// Hence the workaround below:
 		VerticalLayout gridWrapper = WrapperUtils.wrapSizeFullVertical(
-			createBreadcrumbs(),
+			archivesTabPanel,
 			new ViewSection(
 				WrapperUtils.wrapWidthFullRightHorizontal(searchBox),
-				archivesTabPanel,
 				modelGrid
 			),
 			WrapperUtils.wrapWidthFullCenterHorizontal(new UploadModelButton(projectId))
 		);
-		return gridWrapper;
+		gridWrapper.addClassName("content");
+		
+		return WrapperUtils.wrapSizeFullVertical(
+				createBreadcrumbs(),
+				gridWrapper);
 	}
 
 	private void setupArchivesTabPanel() {


### PR DESCRIPTION
#### Changes
- [x] Position Models/Archive tabs outside of the white area

#### Before
![image](https://user-images.githubusercontent.com/1197406/74279066-10adfa80-4ccf-11ea-9fb7-81eac45b9935.png)

#### PR Screenshot
![image](https://user-images.githubusercontent.com/13184582/74502079-48af7a80-4f27-11ea-921a-87191f14f050.png)

Closes #852 