### PR TITLE
Set sender name for Sendgrid emails

### DIFF
--- a/src/main/java/io/skymind/pathmind/services/notificationservice/MailHelper.java
+++ b/src/main/java/io/skymind/pathmind/services/notificationservice/MailHelper.java
@@ -45,8 +45,11 @@ public class MailHelper
 	@Value("${sendgrid.api.key}")
 	private String apiKey;
 
-	@Value("${pathmind.email.from}")
-	private String from;
+	@Value("${pathmind.email.from.email}")
+	private String fromEmail;
+
+	@Value("${pathmind.email.from.name}")
+	private String fromName;
 
 	/**
 	 * Sends an email using SendGrid
@@ -84,7 +87,7 @@ public class MailHelper
 			throw new PathMindException("Email fields are missing");
 		}
 		Mail mail = new Mail();
-		mail.setFrom(new Email(from));
+		mail.setFrom(createFromEmail());
 		mail.setTemplateId(verificationEmailTemplateId);
 
 		Personalization personalization = new Personalization();
@@ -102,7 +105,7 @@ public class MailHelper
 			throw new PathMindException("Email fields are missing");
 		}
 		Mail mail = new Mail();
-		mail.setFrom(new Email(from));
+		mail.setFrom(createFromEmail());
 		mail.setTemplateId(resetPasswordTemplateId);
 
 		Personalization personalization = new Personalization();
@@ -132,7 +135,7 @@ public class MailHelper
 			throw new PathMindException("Email fields are missing");
 		}
 		Mail mail = new Mail();
-		mail.setFrom(new Email(from));
+		mail.setFrom(createFromEmail());
 		mail.setTemplateId(isSuccessful ? trainingCompletedTemplateId : trainingFailedTemplateId);
 		
 		Personalization personalization = new Personalization();
@@ -143,5 +146,10 @@ public class MailHelper
 		personalization.addTo(new Email(to));
 		mail.addPersonalization(personalization);
 		return mail;
+	}
+	
+	
+	private Email createFromEmail() {
+		return new Email(fromEmail, fromName);
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,7 +55,8 @@ sendgrid.trainingcompleted-mail.id=d-8ad31743d0e94abdbe926886d4ae7bae
 sendgrid.trainingfailed-mail.id=d-f69138f0a99d42a5aaa97fa6ce817675
 
 pathmind.email-sending.enabled=true
-pathmind.email.from=support@pathmind.com
+pathmind.email.from.email=support@pathmind.com
+pathmind.email.from.name=Pathmind
 pathmind.application.url=${APPLICATION_URL:http://localhost:8080}
 pathmind.contact-support.address=mailto:support@pathmind.com
 


### PR DESCRIPTION
Closes #756 

`pathmind.email.from` parameter is removed from `application.properties`, instead two new parameters are added : `pathmind.email.from.name` and `pathmind.email.from.email`

The subjects for two mail templates `verificationMail` and `resetPassword` was empty (`-`).
I changed them directly in Sendmail:
- `verificationMail` : `Validate your email address`
-  `resetPassword` : `Reset your password`