### PR TITLE
Updated training errors

### DIFF
--- a/src/main/resources/db/changelog/db.initial.xml
+++ b/src/main/resources/db/changelog/db.initial.xml
@@ -947,6 +947,7 @@
     <changeSet id="20200224-01" author="onur@vaadin.com">
         <update tableName="TRAINING_ERROR">
             <column name="DESCRIPTION" value="Training failed to initialize. Please contact the Pathmind team."/>
+            <column name="RESTARTABLE" value="false"/>
             <where>ID = 1</where>
         </update>
         <update tableName="TRAINING_ERROR">
@@ -959,6 +960,7 @@
         </update>
         <update tableName="TRAINING_ERROR">
             <column name="DESCRIPTION" value="Runtime error. Please contact the Pathmind team."/>
+            <column name="RESTARTABLE" value="false"/>
             <where>ID = 4</where>
         </update>
         <update tableName="TRAINING_ERROR">


### PR DESCRIPTION
Closes #945 

Set the descriptions of the errors and `restartable` fields are set to `false`
