### PR TITLE
Increase jenkins pvc

### DIFF
--- a/infra/helm/jenkins/templates/pvc.yaml
+++ b/infra/helm/jenkins/templates/pvc.yaml
@@ -7,5 +7,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 100Gi
 


### PR DESCRIPTION
@slinlee Originaly we had only 2GB for Jenkins hard disk and that is too low, i have increase it to 100GB.