### PR TITLE
Notification close button is changed to small x icon

### DIFF
--- a/src/main/java/io/skymind/pathmind/ui/components/CloseableNotification.java
+++ b/src/main/java/io/skymind/pathmind/ui/components/CloseableNotification.java
@@ -1,9 +1,11 @@
 package io.skymind.pathmind.ui.components;
 
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
+
+import io.skymind.pathmind.ui.utils.WrapperUtils;
 
 public class CloseableNotification extends Notification {
 
@@ -13,13 +15,10 @@ public class CloseableNotification extends Notification {
 		contentLabel.setMaxWidth("350px");
 		contentLabel.getStyle().set("display", "inline-block");
 		contentLabel.getStyle().set("padding-right", "15px");
-		add(contentLabel);
 
-		Button closeButton = new Button("Close");
-		closeButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		Button closeButton = new Button(VaadinIcon.CLOSE_SMALL.create());
 		closeButton.addClickListener(event -> close());
-		add(closeButton);
-
+		add(WrapperUtils.wrapSizeFullCenterHorizontal(contentLabel, closeButton));
 		setPosition(Notification.Position.TOP_CENTER);
 		setDuration(5000);
 	}


### PR DESCRIPTION
Closes #1017 

Success notification looks like:
![Screenshot 2020-03-03 at 14 49 59](https://user-images.githubusercontent.com/33827141/75777470-b6003f80-5d5e-11ea-9534-e03e40a832c3.png)

Error notification (with multiple lines):
![Screenshot 2020-03-03 at 14 50 10](https://user-images.githubusercontent.com/33827141/75777475-b7ca0300-5d5e-11ea-93d9-515f5e3f0cc7.png)
