### PR TITLE
Extend training time to 24 hour per training

### DIFF
--- a/src/main/java/io/skymind/pathmind/services/training/constant/RunConstants.java
+++ b/src/main/java/io/skymind/pathmind/services/training/constant/RunConstants.java
@@ -15,7 +15,7 @@ public final class RunConstants {
 	 * Number of possible iterations for PBT run
 	 */
 	public static final int PBT_RUN_ITERATIONS = 250;
-	public static final int PBT_MAX_TIME_IN_SEC = 150 * MINUTE;
+	public static final int PBT_MAX_TIME_IN_SEC = 24 * HOUR; // Setting this for GHD March 14, 2020 - Slin
 	public static final int PBT_NUM_SAMPLES = 10;
 
 	public static final String DISCOVERY_RUN_LEARNING_RATES = "DISCOVERY_RUN_LEARNING_RATES";


### PR DESCRIPTION
GHD training is being cut off before they get the better results. We'll temporarily extend this in production so they can deliver something for their clients.

2.5 hours per worker -> 24 hours.

### Before
At 2.5 hours per worker, 7 iterations are completed per worker and the whole training takes 9 hours.

<img width="1782" alt="Screen Shot 2020-03-13 at 12 43 36 PM" src="https://user-images.githubusercontent.com/1197406/76691328-043afb80-6607-11ea-8e38-f0d791dd2711.png">
