### PR TITLE
Install node in the vagrant image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,7 @@ Vagrant.configure("2") do |config|
    
     # Add node sources
     wget https://deb.nodesource.com/setup_13.x && \
-	  bash ./setup_13.x && \
-   
+    bash ./setup_13.x && \
     apt-get update -y
 
     # Install postgresql, maven, node and java


### PR DESCRIPTION
I had removed this before, but it's required to run the webapp. I use the same version of node used in the production dockerfile.