### PR TITLE
Make the loading icon spin on the experiment page

### DIFF
--- a/pathmind-webapp/frontend/styles/views/experiment/experiment-navbar.css
+++ b/pathmind-webapp/frontend/styles/views/experiment/experiment-navbar.css
@@ -54,6 +54,12 @@
   background-repeat: no-repeat;
   background-size: 100% auto;
   background-position: center;
+  animation: spin 5s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 iron-icon[icon="vaadin:check-circle"] {


### PR DESCRIPTION
The icon that indicates an experiment is starting/running looks like a spinner. Because it didn't spin, it looked like the page and app was broken. This adds a slow spinning animation effect to show that things are still running.

Closes #1087

### Before: (No animation)

![image](https://user-images.githubusercontent.com/1197406/76905627-8faec980-685f-11ea-86ca-e1a0e2e1b106.png)

### After (animated)

![spinningFile](https://user-images.githubusercontent.com/1197406/76905645-963d4100-685f-11ea-8cb7-3f0fe0f2f73f.gif)


