### PR TITLE
timeout-before-testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,7 @@ pipeline {
 		script {
 			try {
 				echo "Running tests"
+				sh "sleep 120"
 				sh "if [ -d pathmind-bdd-tests ]; then rm -rf pathmind-bdd-tests; fi"
 				sh "git clone git@github.com:SkymindIO/pathmind-bdd-tests.git"
 				sh "cd pathmind-bdd-tests; mvn clean verify -Dheadless=true -Denvironment=pathmind-dev"


### PR DESCRIPTION
We need this to make sure dev is really deployed before starting the tests.