### PR TITLE
Change PBT settings for faster training

### DIFF
--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/constant/RunConstants.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/constant/RunConstants.java
@@ -15,8 +15,8 @@ public final class RunConstants {
 	 * Number of possible iterations for PBT run
 	 */
 	public static final int PBT_RUN_ITERATIONS = 250;
-	public static final int PBT_MAX_TIME_IN_SEC = 24 * HOUR; // Setting this for GHD March 14, 2020 - Slin
-	public static final int PBT_NUM_SAMPLES = 10;
+	public static final int PBT_MAX_TIME_IN_SEC = 12 * HOUR;
+	public static final int PBT_NUM_SAMPLES = 8;
 
 	public static final String DISCOVERY_RUN_LEARNING_RATES = "DISCOVERY_RUN_LEARNING_RATES";
 	public static final String DISCOVERY_RUN_GAMMAS = "DISCOVERY_RUN_GAMMAS";


### PR DESCRIPTION
- Max time is set to 12 hours (down from 24 hours)
- Reduce the number of samples from 10 to 8.

Resolves #1215