### PR TITLE
Increase the postgresql timeout on PR tests

### DIFF
--- a/Jenkinsfile_PRs
+++ b/Jenkinsfile_PRs
@@ -147,7 +147,7 @@ pipeline {
                         sh "helm upgrade --install postgres ${WORKSPACE}/infra/helm/postgres --set namespace=${env.BUILD_NUMBER} -n ${env.BUILD_NUMBER}"
 
                         echo "Waiting for psql to come up"
-                        sh "timeout 300 bash -c 'while ! pg_isready  -h postgres-${env.BUILD_NUMBER} -q; do sleep 5; done'"
+                        sh "timeout 900 bash -c 'while ! pg_isready  -h postgres-${env.BUILD_NUMBER} -q; do sleep 5; done'"
 
                         echo "Creating user"
                         userpass='\\$2a\\$10\\$mnh8uyby0UslZw1fiKXc9uvX2370CJJMjYg3U7ztmVXRXmQo3VJLK'


### PR DESCRIPTION
@slinlee Some of the tests fail because the postgres is not ready. So i increased the timeout.