### PR TITLE
Disable startup probe on deployments

### DIFF
--- a/infra/helm/pathmind/templates/deployment.yaml
+++ b/infra/helm/pathmind/templates/deployment.yaml
@@ -31,18 +31,13 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 60
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 10
+          #startupProbe:
+          #  httpGet:
+          #    path: /
+          #    port: 80
+          #  initialDelaySeconds: 30
+          #  periodSeconds: 10
+          #  failureThreshold: 10
           env:
             - name: APPLICATION_URL
               value: "{{ .Values.env.APPLICATION_URL }}"


### PR DESCRIPTION
@slinlee I disabled the probes as they were crashing the webapp, 

There is an option for startupProbe but is not available in our kubernetes version so i added it and commented it and i will create an issue to upgrade kubernetes.