### PR TITLE
Remove focus ring style from Archive button on dashboard item menu

### DIFF
--- a/pathmind-webapp/frontend/styles/components/vaadin-context-menu-list-box.css
+++ b/pathmind-webapp/frontend/styles/components/vaadin-context-menu-list-box.css
@@ -1,3 +1,7 @@
 [part="items"] ::slotted(.vaadin-menu-item) {
   cursor: pointer;
 }
+
+[part="items"] ::slotted([focus-ring]:not([disabled])) {
+  box-shadow: none;
+}


### PR DESCRIPTION
That dashboard item menu is already the context menu from vaadin. The ring (a box-shadow which looked like a border) was the style for the focused state of the menu items.

#### PR Screenshot
![image](https://user-images.githubusercontent.com/13184582/79184937-22835980-7e48-11ea-84d4-abd1f822ab41.png)

Closes #1378