### PR TITLE
Fixes highlighting variable indexes greater than 9

### DIFF
--- a/pathmind-webapp/frontend/src/juicy-ace-editor/juicy-ace-editor-variable-names.js
+++ b/pathmind-webapp/frontend/src/juicy-ace-editor/juicy-ace-editor-variable-names.js
@@ -50,7 +50,7 @@ function pushTokensForPlaceholder(renderTokens, placeholder) {
         value: variableIndex + " "
       },
       {
-        type: "reward_variable variable-color-" + variableIndex,
+        type: "reward_variable variable-color-" + (variableIndex % 10),
         value: variableName
       }
     );


### PR DESCRIPTION
Closes #1431 

I come across to this issue while reviewing a PR. Now, variable-indexes > 9 are also highlighted.

<img width="1346" alt="Screenshot 2020-04-21 at 12 58 32" src="https://user-images.githubusercontent.com/33827141/79852858-ed3eb480-83cf-11ea-9141-d3bc015dc325.png">
 