### PR TITLE
Disable Rename Project button on click (#1446)

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/project/components/dialogs/RenameProjectDialog.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/project/components/dialogs/RenameProjectDialog.java
@@ -16,27 +16,27 @@ import io.skymind.pathmind.webapp.ui.components.LabelFactory;
 import io.skymind.pathmind.webapp.ui.constants.CssMindPathStyles;
 
 public class RenameProjectDialog extends Dialog {
-
 	private TextField projectName;
 	private Button rename;
 	private Button cancel;
-	
+
 	private Binder<Project> binder;
-	
+
 	public RenameProjectDialog(Project project, ProjectDAO projectDao, SerializableConsumer<String> updatedProjectNameConsumer) {
 		binder = new Binder<>();
 		projectName = new TextField("Project name");
-		
+
 		rename = new Button("Rename Project", evt -> updateProjectName(projectDao, updatedProjectNameConsumer));
+		rename.setDisableOnClick(true);
 		rename.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
 		rename.addClickShortcut(Key.ENTER);
-		
+
 		cancel = new Button("Cancel", evt -> close());
 		cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 		cancel.setClassName("cancel-button");
 		HorizontalLayout footer = new HorizontalLayout(cancel, rename);
 		footer.setClassName("dialog-footer");
-		
+
 		add(LabelFactory.createLabel("Rename project", CssMindPathStyles.SECTION_TITLE_LABEL), projectName, footer);
 
 		projectName.focus();


### PR DESCRIPTION
#### Notes
The click event listener we can set on the button is a server side listener. If we want to manipulate the client-side in the server side listener, by the time the code is executed, the project name would have been saved. In short, there is no client-side click listener available for our usage from Vaadin API. 

However, Vaadin provided an option to disable the button on click with `setDisableOnClick(true);` which they execute client-side JS within their Button class. I double-checked with @onuridrisoglu and the conclusion is that disabling the button on click should achieve the purpose - not letting users click the button.

For other client-side changes like showing a "Submitting...." text, it could only be implemented with a server roundtrip, which is not suitable for the case.

Closes #1446 