### PR TITLE
Add vpc endpoint to s3 to reduce nat gateway cost

### DIFF
--- a/infra/terraform/dev/terraform.tfvars
+++ b/infra/terraform/dev/terraform.tfvars
@@ -1,4 +1,5 @@
 region="us-east-1"
+vpc_id="vpc-05fdfd103738ac3f4"
 domain_name="devpathmind.com"
 appdomain="dev."
 subdomain="dev."

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -1,4 +1,5 @@
 variable "region" { default = "us-east-1"}
+variable "vpc_id" { }
 variable "awsaccesskey" {}
 variable "awssecretaccesskey" {}
 variable "domain_name" {}

--- a/infra/terraform/dev/vpc_endpoint.tf
+++ b/infra/terraform/dev/vpc_endpoint.tf
@@ -1,0 +1,4 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${var.vpc_id}"
+  service_name = "com.amazonaws.${var.region}.s3"
+}

--- a/infra/terraform/prod/terraform.tfvars
+++ b/infra/terraform/prod/terraform.tfvars
@@ -1,4 +1,5 @@
 region="us-east-1"
+vpc_id="vpc-085b560126f4d3051"
 domain_name="devpathmind.com"
 appdomain=""
 subdomain=""

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -1,4 +1,5 @@
 variable "region" { default = "us-east-1"}
+variable "vpc_id" {}
 variable "awsaccesskey" {}
 variable "awssecretaccesskey" {}
 variable "domain_name" {}

--- a/infra/terraform/prod/vpc_endpoint.tf
+++ b/infra/terraform/prod/vpc_endpoint.tf
@@ -1,0 +1,4 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${var.vpc_id}"
+  service_name = "com.amazonaws.${var.region}.s3"
+}


### PR DESCRIPTION
@slinlee I noticed the bill for NAT Gateway is high due to s3 uploads in the training's. Creating a vpc endpoint to s3 the traffic does not go through the Nat gateway, instead it goes via the VPC.