### PR TITLE
Clear selection after setting value for reward fn editor (#1381)

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/juicy/JuicyAceEditor.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/juicy/JuicyAceEditor.java
@@ -22,69 +22,69 @@ import io.skymind.pathmind.webapp.ui.components.juicy.theme.JuicyAceTheme;
 @JavaScript("./src/juicy-ace-editor/juicy-ace-editor-variable-names.js")
 @JsModule("./src/juicy-ace-editor/juicy-ace-editor-npm.min.js")
 public class JuicyAceEditor extends AbstractSinglePropertyField<JuicyAceEditor, String> implements HasSize, Focusable<JuicyAceEditor> {
-    public JuicyAceEditor() {
-        super("value", "", false);
-    }
+	public JuicyAceEditor() {
+		super("value", "", false);
+	}
 
-    public void setMode(JuicyAceMode mode) {
-        this.getElement().setAttribute("mode", "ace/mode/" + mode);
-    }
+	public void setMode(JuicyAceMode mode) {
+		this.getElement().setAttribute("mode", "ace/mode/" + mode);
+	}
 
-    public void setTheme(JuicyAceTheme theme) {
-        this.getElement().setAttribute("theme", "ace/theme/" + theme);
-    }
+	public void setTheme(JuicyAceTheme theme) {
+		this.getElement().setAttribute("theme", "ace/theme/" + theme);
+	}
 
-    public void setFontsize(Integer fontsize) {
-        this.getElement().setAttribute("fontsize", String.valueOf(fontsize));
-    }
+	public void setFontsize(Integer fontsize) {
+		this.getElement().setAttribute("fontsize", String.valueOf(fontsize));
+	}
 
-    public void setSofttabs(Boolean softtabs) {
-        this.getElement().setAttribute("softtabs", softtabs);
-    }
+	public void setSofttabs(Boolean softtabs) {
+		this.getElement().setAttribute("softtabs", softtabs);
+	}
 
-    public void setTabsize(Integer tabsize) {
-        this.getElement().setAttribute("tabsize", String.valueOf(tabsize));
-    }
+	public void setTabsize(Integer tabsize) {
+		this.getElement().setAttribute("tabsize", String.valueOf(tabsize));
+	}
 
-    public void setReadonly(Boolean readonly) {
-        this.getElement().setAttribute("readonly", readonly);
-    }
+	public void setReadonly(Boolean readonly) {
+		this.getElement().setAttribute("readonly", readonly);
+	}
 
-    public void setWrapmode(Boolean wrapmode) {
-        this.getElement().setAttribute("wrapmode", wrapmode);
-    }
+	public void setWrapmode(Boolean wrapmode) {
+		this.getElement().setAttribute("wrapmode", wrapmode);
+	}
 
-    public void setMaxLines(Integer maxLines) {
-        this.getElement().setAttribute("max-lines", String.valueOf(maxLines));
-    }
+	public void setMaxLines(Integer maxLines) {
+		this.getElement().setAttribute("max-lines", String.valueOf(maxLines));
+	}
 
-    public void setMinLines(Integer minLines) {
-        this.getElement().setAttribute("min-lines", String.valueOf(minLines));
-    }
+	public void setMinLines(Integer minLines) {
+		this.getElement().setAttribute("min-lines", String.valueOf(minLines));
+	}
 
-    public void setShadowStyle(String shadowStyle) {
-        this.getElement().setAttribute("shadow-style", String.valueOf(shadowStyle));
-    }
+	public void setShadowStyle(String shadowStyle) {
+		this.getElement().setAttribute("shadow-style", String.valueOf(shadowStyle));
+	}
 
-    public void clear() {
-        this.getElement().setProperty("value", "");
-    }
+	public void clear() {
+		this.getElement().setProperty("value", "");
+	}
 
-    public void setValue(String value) {
-        this.getElement().setProperty("value", value);
-    	getElement().executeJs("$0.editor.clearSelection()");
-    }
+	public void setValue(String value) {
+		this.getElement().setProperty("value", value);
+		getElement().executeJs("$0.editor.clearSelection()");
+	}
 
-    @Synchronize({"change"})
-    public String getValue() {
-        return this.getElement().getProperty("value");
-    }
-    
-    protected void addVariableNameSupport() {
-    	getElement().executeJs("window.Pathmind.CodeEditor.addVariableNamesSupport($0)");
-    }
-    
-    protected void setVariableNames(JsonObject variableNames) {
-    	getElement().executeJs("window.Pathmind.CodeEditor.setVariableNames($0)", variableNames);
-    }
+	@Synchronize({"change"})
+	public String getValue() {
+		return this.getElement().getProperty("value");
+	}
+	
+	protected void addVariableNameSupport() {
+		getElement().executeJs("window.Pathmind.CodeEditor.addVariableNamesSupport($0)");
+	}
+	
+	protected void setVariableNames(JsonObject variableNames) {
+		getElement().executeJs("window.Pathmind.CodeEditor.setVariableNames($0)", variableNames);
+	}
 }


### PR DESCRIPTION
#### Notes
The highlighting only occurs if the user switches between experiments with different reward function content. If the reward functions are exactly the same, the highlighting does not happen. This is because within ace editor's source code, the value is only being set when the new value and the current value are different.

The default behaviour of the ace editor after `setValue` is to select the whole value.
https://stackoverflow.com/questions/18614169/set-value-for-ace-editor-without-selecting-the-whole-editor

Calling `clearSelection()` in javascript solves the problem.

Closes #1381 