### PR TITLE
Hide markers in Policy chart

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/PolicyChartPanel.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/PolicyChartPanel.java
@@ -113,7 +113,6 @@ public class PolicyChartPanel extends VerticalLayout implements PolicyUpdateSubs
         dataSeries.setId(Long.toString(policy.getId()));
         PlotOptionsSeries plotOptions = isBestPolicy ? createActiveSeriesPlotOptions() : createPassiveSeriesPlotOptions();
         plotOptions.setMarker(new Marker(false));
-        plotOptions.setAnimation(false);
         dataSeries.setPlotOptions(plotOptions);
         return dataSeries;
     }


### PR DESCRIPTION
Closes #1501

@slinlee @ejunprung I applied the `#1a2949` also to the markers:
<img width="688" alt="Screenshot 2020-05-05 at 13 09 54" src="https://user-images.githubusercontent.com/33827141/81056713-abcffe00-8ed3-11ea-9fc4-b4f48d2a0cdd.png">
But I think, the graph looks better without the markers:
<img width="680" alt="Screenshot 2020-05-05 at 13 13 05" src="https://user-images.githubusercontent.com/33827141/81056771-ca35f980-8ed3-11ea-9004-95ae85439e31.png">

Normally, the markers are hidden automatically if the data is dense, in other words, they are displayed as long as they are not overlapping. 

Let me know what do you think about disabling markers, I can also enable it, and override it's color. 