### PR TITLE
Switch back to 16 CPU and 32GB for training

### DIFF
--- a/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/api/AWSApiClient.java
+++ b/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/api/AWSApiClient.java
@@ -124,7 +124,7 @@ public class AWSApiClient {
     public String jobSubmit(String jobId, RunType type) throws JsonProcessingException {
         final String mockType = type == null ? null : type.toString();
         Job job = new Job(bucketName, jobId, mockCycle, mockType);
-        job.setEc2InstanceType(EC2InstanceType.IT_36CPU_72GB);
+        job.setEc2InstanceType(EC2InstanceType.IT_16CPU_32GB);
 
         SendMessageRequest send_msg_request = new SendMessageRequest()
                 .withQueueUrl(queueUrl)


### PR DESCRIPTION
This switches the training instance types back to 16 cpu and 32 gb

This is the change that added 36 CPU and switched to use it.

https://github.com/SkymindIO/pathmind-webapp/pull/1537