### PR TITLE
Increase the reward function length to 65535

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/NewExperimentView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/NewExperimentView.java
@@ -1,7 +1,6 @@
 package io.skymind.pathmind.webapp.ui.views.experiment;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dependency.CssImport;
@@ -127,10 +126,10 @@ public class NewExperimentView extends PathMindDefaultView implements HasUrlPara
 		rewardFnEditorPanel.setPadding(false);
 		rewardFnEditorPanel.setSpacing(false);
 
-		HorizontalLayout errorAndNotesContaner = WrapperUtils.wrapWidthFullHorizontal(getErrorsPanel(), createNotesField());
-		errorAndNotesContaner.setClassName("error-and-notes-container");
+		HorizontalLayout errorAndNotesContainer = WrapperUtils.wrapWidthFullHorizontal(getErrorsPanel(), createNotesField());
+		errorAndNotesContainer.setClassName("error-and-notes-container");
 
-		mainPanel.add(WrapperUtils.wrapWidthFullBetweenHorizontal(panelTitle, startRunButton), rewardFnEditorPanel, errorAndNotesContaner);
+		mainPanel.add(WrapperUtils.wrapWidthFullBetweenHorizontal(panelTitle, startRunButton), rewardFnEditorPanel, errorAndNotesContainer);
 		mainPanel.setClassName("view-section");
 		return mainPanel;
 	}


### PR DESCRIPTION
This is not a DB limit. I just picked it to be bigger than 1000 and a
customer is already running into this limit.

Fixes #1598 

The 60,000+ char reward function is saved to the DB and starts training okay:

![image](https://user-images.githubusercontent.com/1197406/82501055-70275d80-9aa9-11ea-8acf-e7591adbb579.png)

When it's longer than 65,535 chars, it shows the red error message and prevents the training from starting.
