### PR TITLE
Removed workaround for deactivating shortcut listener

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/project/components/panels/CreateANewProjectPanel.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/project/components/panels/CreateANewProjectPanel.java
@@ -47,14 +47,4 @@ public class CreateANewProjectPanel extends VerticalLayout
 		ProjectBinders.bindProjectName(binder, projectDao, projectNameTextField);
 	}
 	
-	/**
-	 * <code>createProjectButton</code> has a click shortcut that stays active as long as the button is visible and attached
-	 * For this reason, changing also the visibility of the button, when visibility of panel is changed
-	 * Filed an issue https://github.com/vaadin/flow/issues/7033 for this
-	 */
-	@Override
-	public void setVisible(boolean visible) {
-		super.setVisible(visible);
-		createProjectButton.setVisible(visible);
-	}
 }


### PR DESCRIPTION
Closes #518 

Removed the workaround not because the original issue is fixed, but because the project creation flow is changed, the workaround is not necessary anymore.