### PR TITLE
Fix liveness probes for webapp and updater

### DIFF
--- a/infra/helm/pathmind/templates/deployment.yaml
+++ b/infra/helm/pathmind/templates/deployment.yaml
@@ -37,19 +37,9 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            failureThreshold: 10
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 80
-            initialDelaySeconds: 30
-            periodSeconds: 15
+      {{- with .Values.probes }}
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
           env:
             - name: APPLICATION_URL
               value: "{{ .Values.env.APPLICATION_URL }}"

--- a/infra/helm/pathmind/values_dev-slot.yaml
+++ b/infra/helm/pathmind/values_dev-slot.yaml
@@ -74,3 +74,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15

--- a/infra/helm/pathmind/values_dev-updater.yaml
+++ b/infra/helm/pathmind/values_dev-updater.yaml
@@ -74,3 +74,4 @@ tolerations: []
 
 affinity: {}
 
+probes: {}

--- a/infra/helm/pathmind/values_dev.yaml
+++ b/infra/helm/pathmind/values_dev.yaml
@@ -75,3 +75,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15

--- a/infra/helm/pathmind/values_prod-slot.yaml
+++ b/infra/helm/pathmind/values_prod-slot.yaml
@@ -75,3 +75,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15

--- a/infra/helm/pathmind/values_prod-updater.yaml
+++ b/infra/helm/pathmind/values_prod-updater.yaml
@@ -74,3 +74,4 @@ tolerations: []
 
 affinity: {}
 
+probes: {}

--- a/infra/helm/pathmind/values_prod.yaml
+++ b/infra/helm/pathmind/values_prod.yaml
@@ -75,3 +75,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15

--- a/infra/helm/pathmind/values_test-slot.yaml
+++ b/infra/helm/pathmind/values_test-slot.yaml
@@ -75,3 +75,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15

--- a/infra/helm/pathmind/values_test-updater.yaml
+++ b/infra/helm/pathmind/values_test-updater.yaml
@@ -74,3 +74,4 @@ tolerations: []
 
 affinity: {}
 
+probes: {}

--- a/infra/helm/pathmind/values_test.yaml
+++ b/infra/helm/pathmind/values_test.yaml
@@ -75,3 +75,17 @@ tolerations: []
 
 affinity: {}
 
+probes:
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 10
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 80
+    initialDelaySeconds: 30
+    periodSeconds: 15


### PR DESCRIPTION
I noticed that the updater was crashing and the reason was because it was using the wrong probes. This PR is to fix it.