### PR TITLE
Enable Scenario: check running experiment page archive btn, move second running experiment to archived

### DIFF
--- a/pathmind-bdd-tests/src/test/resources/features/experiment/experimentArchive.feature
+++ b/pathmind-bdd-tests/src/test/resources/features/experiment/experimentArchive.feature
@@ -15,31 +15,30 @@ Feature: Experiment archive
     Then Check that the 'Stop Training' confirmation dialog is shown
     When In confirmation dialog click in 'Stop Training' button
 
-    #Disable due to the bug https://github.com/SkymindIO/pathmind-webapp/issues/1877
-#  Scenario: Check running experiment page archive btn, move second running experiment to archived
-#    Given Login to the pathmind
-#    When Create new CoffeeShop project with single reward function
-#    Then Click project start run button
-#    Then Click in 'New Experiment' button
-#    Then Click project start run button
-#    Then Click side nav archive button for 'Experiment #1'
-#    When In confirmation dialog click in 'Archive' button
-#    When Click in 'Model #1' button
-#    When Check that model/experiment name '1' NOT exist in archived/not archived tab
-#    Then Check that model/experiment name '2' exist in archived/not archived tab
-#    When Open projects/model/experiment archived tab
-#    Then Check that model/experiment name '1' exist in archived/not archived tab
-#    When Check that model/experiment name '2' NOT exist in archived/not archived tab
-#    Then Click the experiment name 1
-#    When Click in 'Stop Training' button
-#    Then Check that the 'Stop Training' confirmation dialog is shown
-#    When In confirmation dialog click in 'Stop Training' button
-#    When Click in 'Model #1' button
-#    Then Click the experiment name 2
-#    When Click in 'Stop Training' button
-#    Then Check that the 'Stop Training' confirmation dialog is shown
-#    When In confirmation dialog click in 'Stop Training' button
-#    When Click in 'Model #1' button
+  Scenario: Check running experiment page archive btn, move second running experiment to archived
+    Given Login to the pathmind
+    When Create new CoffeeShop project with single reward function
+    Then Click project start run button
+    Then Click in 'New Experiment' button
+    Then Click project start run button
+    Then Click side nav archive button for 'Experiment #1'
+    When In confirmation dialog click in 'Archive' button
+    When Click in 'Model #1' button
+    When Check that model/experiment name '1' NOT exist in archived/not archived tab
+    Then Check that model/experiment name '2' exist in archived/not archived tab
+    When Open projects/model/experiment archived tab
+    Then Check that model/experiment name '1' exist in archived/not archived tab
+    When Check that model/experiment name '2' NOT exist in archived/not archived tab
+    Then Click the experiment name 1
+    When Click in 'Stop Training' button
+    Then Check that the 'Stop Training' confirmation dialog is shown
+    When In confirmation dialog click in 'Stop Training' button
+    When Click in 'Model #1' button
+    Then Click the experiment name 2
+    When Click in 'Stop Training' button
+    Then Check that the 'Stop Training' confirmation dialog is shown
+    When In confirmation dialog click in 'Stop Training' button
+    When Click in 'Model #1' button
 
   Scenario: Check running experiment page archive btn, move second draft experiment to archived
     Given Login to the pathmind


### PR DESCRIPTION
Closes #1877 

@EvgeniyEA I think the issue is fixed recently by another PR, I couldn't reproduce the issue.
In this PR, I just enabled the scenario, and that specific scenario is passed in Jenkins built as well.