### PR TITLE
Crop messages if their len is more that what's defined in DB

### DIFF
--- a/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
+++ b/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
@@ -47,6 +47,11 @@ public class AWSExecutionProvider implements ExecutionProvider {
     public static final String RLLIB_ERROR_PREFIX = "x-rllib_error";
     public static final String SUCCESS_MESSAGE_PREFIX = "x-success_message";
     public static final String WARNING_MESSAGE_PREFIX = "x-warning_message";
+    
+    public static final int RLLIB_MAX_LEN = 1024;
+    public static final int SUCCESS_MAX_LEN = 1024;
+    public static final int WARNING_MAX_LEN = 1024;
+    
     private static final Predicate<String> ERROR_KEY_MATCH = // todo: possible even get a date of error as second match group
             Pattern.compile("(.)*error_(.*)txt$", Pattern.CASE_INSENSITIVE).asMatchPredicate();
 


### PR DESCRIPTION
Closes #1921 

I don't know how critical these message contents are, that's why instead of increasing the column size, I cropped the message, in case its longer than 1024 char.