### PR TITLE
Modify help guide test assert from title to article name

### DIFF
--- a/pathmind-bdd-tests/src/main/java/io/skymind/pathmind/bddtests/page/HelpPage.java
+++ b/pathmind-bdd-tests/src/main/java/io/skymind/pathmind/bddtests/page/HelpPage.java
@@ -14,7 +14,7 @@ public class HelpPage extends PageObject {
 
     public void checkConvertingModelsToSupportTuplesPageElements() {
         waitABit(5000);
-        assertThat(getDriver().getTitle(), is("Converting models to support Tuples | Pathmind Knowledge Base"));
+        assertThat(getDriver().findElement(By.cssSelector("h1")).getText(), is("Converting models to support Tuples"));
 
     }
 }


### PR DESCRIPTION
Now I see that test `Check tuple article link on model upload step` failed on dev build. Because of the help page title. Some times it `Pathmind says…` some times `Converting models to support Tuples | Pathmind Knowledge Base`
Test assert switched to check the article name.