### PR TITLE
HOTFIX - Prevent user cap warnings by hardcoding to 0 runs

### DIFF
--- a/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/RunRepository.java
+++ b/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/RunRepository.java
@@ -181,14 +181,14 @@ class RunRepository
         // HOTFIX - TODO - remove this after debugging
         // Users are being prevented from running experiments
         return new UserMetrics(0, 0);
-
-        // Must be a customer with no experiments.
-        if(record == null) {
-            return new UserMetrics(0, 0);
-        }
-
-        return new UserMetrics(
-                (Integer)record.getValue("runsToday"),
-                (Integer)record.getValue("runsThisMonth"));
+//
+//        // Must be a customer with no experiments.
+//        if(record == null) {
+//            return new UserMetrics(0, 0);
+//        }
+//
+//        return new UserMetrics(
+//                (Integer)record.getValue("runsToday"),
+//                (Integer)record.getValue("runsThisMonth"));
     }
 }


### PR DESCRIPTION
Customers aren't able to run more experiments. This allows
them to continue while we debug what happened.