### PR TITLE
Make kubernetes API private

### DIFF
--- a/infra/terraform/modules/aws-eks/main.tf
+++ b/infra/terraform/modules/aws-eks/main.tf
@@ -30,12 +30,12 @@ provider "kubernetes" {
 }
 
 module "cluster" {
-  source          = "terraform-aws-modules/eks/aws"
-  cluster_name    = var.cluster_name
-  cluster_version = var.cluster_version
-  subnets         = data.aws_subnet_ids.selected.ids
-  vpc_id          = data.aws_vpc.selected.id
-  cluster_endpoint_private_access	= true
+  source                                = "terraform-aws-modules/eks/aws"
+  cluster_name                          = var.cluster_name
+  cluster_version                       = var.cluster_version
+  subnets                               = data.aws_subnet_ids.selected.ids
+  vpc_id                                = data.aws_vpc.selected.id
+  cluster_endpoint_private_access       = true
   cluster_endpoint_public_access        = false
 
   worker_groups_launch_template = [


### PR DESCRIPTION
@slinlee This change is make sure that the kubernetes API is only accessible within the AWS VPC, for that i created a bastion host. We do this in order to increase the security because none can access it just over the internet. 