### PR TITLE
Sparkline: show sparkline even if it's flat, show iteration # on tooltip

### DIFF
--- a/pathmind-webapp/frontend/src/experiment/spark-line.js
+++ b/pathmind-webapp/frontend/src/experiment/spark-line.js
@@ -66,9 +66,9 @@ class SparkLine extends PolymerElement {
             </style>
             <svg width="100" height="24" stroke-width="2"></svg>
             <div id="tooltip" hidden="true">
-                <!-- <div class="iteration">
-                    <span class="label">Iteration</span> <span class="data">[[iteration]]</span>
-                </div> -->
+                <div class="iteration">
+                    <span class="label">Iteration</span> #<span class="data">[[iteration]]</span>
+                </div>
                 <div class="value">
                     <span class="label">Mean Value</span> <span class="data">[[value]]</span>
                 </div>
@@ -112,11 +112,15 @@ class SparkLine extends PolymerElement {
         super.ready();
     }
 
-    setSparkLine(dataPoints, variableIndex) {
+    setSparkLine(dataPointsList, variableIndex) {
+        const parsedDataPointsList = JSON.parse(dataPointsList);
+        const iterationList = Object.keys(parsedDataPointsList);
+        const dataPoints = Object.values(parsedDataPointsList);
         const options = {
             onmousemove: (event, dataPoint) => {
               const tooltip = this.$.tooltip;
               this.value = this.isFlat ? this.smallestNum : (this.smallestNum + dataPoint.value).toFixed(2);
+              this.iteration = iterationList[dataPoint.index];
               tooltip.hidden = false;
               tooltip.style.top = `${event.clientY}px`;
               tooltip.style.left = `${event.clientX + 20}px`;
@@ -135,15 +139,15 @@ class SparkLine extends PolymerElement {
         const sumOfDataPoints = originalDataPoints.reduce((a, b) => a+b);
         this.smallestNum = originalDataPoints.reduce((a, b) => Math.min(a, b));
 
-        if (this.checkDataPointsChange(this.smallestNum*originalDataPointsLength, sumOfDataPoints)) {
+        if (this.checkDiff(this.smallestNum*originalDataPointsLength, sumOfDataPoints)) {
             this.isFlat = true;
             return this.processDataPoints(originalDataPoints);
         }
         return originalDataPoints.map(dataPoint => dataPoint - this.smallestNum);
     }
 
-    checkDataPointsChange(smallestNumTimesLength, sumOfDataPoints) {
-        return this.trimInaccurateFloatingPoints(sumOfDataPoints) === this.trimInaccurateFloatingPoints(smallestNumTimesLength);
+    checkDiff(a, b) {
+        return this.trimInaccurateFloatingPoints(a) === this.trimInaccurateFloatingPoints(b);
     }
 
     trimInaccurateFloatingPoints(num) {

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/SparkLine.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/SparkLine.java
@@ -1,7 +1,8 @@
 package io.skymind.pathmind.webapp.ui.components;
 
-import elemental.json.Json;
-import elemental.json.JsonArray;
+import java.util.Map;
+
+import com.google.gson.Gson;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -17,17 +18,8 @@ public class SparkLine extends PolymerTemplate<TemplateModel> implements HasStyl
         super();
     }
     
-    public void setSparkLine(double[] sparklineData, int index) {
-        getElement().callJsFunction("setSparkLine", convertToJsArray(sparklineData), index);
-    }
-    
-    public JsonArray convertToJsArray(double[] sparklineData) {
-		JsonArray json = Json.createArray();
-        if (sparklineData != null) {
-            for (int i = 0; i < sparklineData.length; i++) {
-                json.set(i, sparklineData[i]);
-            }
-        }
-        return json;
+    public void setSparkLine(Map<Integer, Double> sparklineData, int index) {
+        Gson gson = new Gson();
+        getElement().callJsFunction("setSparkLine", gson.toJson(sparklineData), index);
     }
 }


### PR DESCRIPTION
#### Need Help for the rest of #1953
Unlike the reward_score table in DB, currently the metrics table doesn't have the episode_count column so the sparkline can't get the episode count. I don't touch the DB so if anyone can add the episode count to the DB that would be great to help move forward #1953 on a future PR.

#### Changes
- [x] update sparkline to show even if it's flat
- [x] update sparkline Java file to accept iteration
- [x] pass iteration into sparkline Java file and then to sparkline Polymer file

#### PR Screenshots
![image](https://user-images.githubusercontent.com/13184582/91039989-1605dd80-e640-11ea-9b54-1b30a9d90b52.png)
![image](https://user-images.githubusercontent.com/13184582/91040269-814faf80-e640-11ea-95f5-1b63cc33e6ff.png)

Closes #2026
Part of #1953