### PR TITLE
add support to clone an event before firing it

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/CloneUtils.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/CloneUtils.java
@@ -1,0 +1,20 @@
+package io.skymind.pathmind.webapp.bus;
+
+import java.io.*;
+
+public class CloneUtils {
+    public static <T> T cloneUsingSerialization(T obj) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutputStream out = new ObjectOutputStream(bos)) {
+            out.writeObject(obj);
+            out.flush();
+            byte[] bytes = bos.toByteArray();
+            try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+                 ObjectInputStream in = new ObjectInputStream(bis)) {
+                return (T) in.readObject();
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Can't clone object", e);
+        }
+    }
+}

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/CloneablePathmindBusEvent.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/CloneablePathmindBusEvent.java
@@ -1,0 +1,5 @@
+package io.skymind.pathmind.webapp.bus;
+
+public interface CloneablePathmindBusEvent extends PathmindBusEvent {
+    CloneablePathmindBusEvent cloneForEventBus();
+}

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/EventBus.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/EventBus.java
@@ -65,7 +65,13 @@ public class EventBus {
         EVENT_BUS.subscribers.get(event.getEventType()).stream()
                 .filter(subscriber -> subscriber.filterSameUI(event) && subscriber.filterBusEvent(event) && subscriber.isAttached())
                 .forEach(subscriber -> {
-                    EXECUTOR_SERVICE.execute(() -> subscriber.handleBusEvent(event));
+                    EXECUTOR_SERVICE.execute(() -> {
+                        PathmindBusEvent eventToFire = event;
+                        if (event instanceof CloneablePathmindBusEvent) {
+                            eventToFire = ((CloneablePathmindBusEvent)event).cloneForEventBus();
+                        }
+                        subscriber.handleBusEvent(eventToFire);
+                    });
         });
     }
 

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/events/PolicyUpdateBusEvent.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/events/PolicyUpdateBusEvent.java
@@ -1,12 +1,13 @@
 package io.skymind.pathmind.webapp.bus.events;
 
+import io.skymind.pathmind.shared.data.Policy;
+import io.skymind.pathmind.webapp.bus.BusEventType;
+import io.skymind.pathmind.webapp.bus.CloneUtils;
+import io.skymind.pathmind.webapp.bus.CloneablePathmindBusEvent;
+
 import java.util.List;
 
-import io.skymind.pathmind.webapp.bus.BusEventType;
-import io.skymind.pathmind.webapp.bus.PathmindBusEvent;
-import io.skymind.pathmind.shared.data.Policy;
-
-public class PolicyUpdateBusEvent implements PathmindBusEvent {
+public class PolicyUpdateBusEvent implements CloneablePathmindBusEvent {
     private List<Policy> policies;
     private long experimentId;
 
@@ -40,5 +41,10 @@ public class PolicyUpdateBusEvent implements PathmindBusEvent {
 
     public long getExperimentId() {
         return experimentId;
+    }
+
+    @Override
+    public PolicyUpdateBusEvent cloneForEventBus() {
+        return new PolicyUpdateBusEvent(CloneUtils.cloneUsingSerialization(this.policies));
     }
 }

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/events/RunUpdateBusEvent.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/events/RunUpdateBusEvent.java
@@ -1,10 +1,11 @@
 package io.skymind.pathmind.webapp.bus.events;
 
 import io.skymind.pathmind.webapp.bus.BusEventType;
-import io.skymind.pathmind.webapp.bus.PathmindBusEvent;
+import io.skymind.pathmind.webapp.bus.CloneUtils;
+import io.skymind.pathmind.webapp.bus.CloneablePathmindBusEvent;
 import io.skymind.pathmind.shared.data.Run;
 
-public class RunUpdateBusEvent implements PathmindBusEvent
+public class RunUpdateBusEvent implements CloneablePathmindBusEvent
 {
 	private Run run;
 
@@ -35,5 +36,10 @@ public class RunUpdateBusEvent implements PathmindBusEvent
 
 	public long getModelId() {
 	    return this.getRun().getModel().getId();
+    }
+
+    @Override
+    public CloneablePathmindBusEvent cloneForEventBus() {
+        return new RunUpdateBusEvent(CloneUtils.cloneUsingSerialization(run));
     }
 }


### PR DESCRIPTION
this is useful when we have multiple subscribers for an event type and each subscriber might change the event, leading to strange bugs at runtime, e.g. a ConcurrentModificationException in a subscriber which is iterating over a list which is modified by other subscriber.