### PR TITLE
Fix #160 Disable tomcat session persistence feature in dev

### DIFF
--- a/pathmind-webapp/src/main/resources/application.properties
+++ b/pathmind-webapp/src/main/resources/application.properties
@@ -8,3 +8,5 @@ pathmind.notification.newRunMonthlyLimit=${NEW_RUN_MONTHLY_LIMIT:1000}
 pathmind.notification.newRunNotificationThreshold=${NEW_RUN_NOTIFICATION_THRESHOLD:90}
 
 logging.pattern.console = %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39} [%3line]){cyan} %clr(:){faint} %m%n%wEx
+
+server.servlet.session.persistent=false


### PR DESCRIPTION
This gets rid of the error that would show up in the server
logs for local dev environments. It does not affect deployed
environments in dev or prod.

The change was prepared originally by Onur. I just rebased it.

