### PR TITLE
Simulation Metrics Vertical Alignment

### DIFF
--- a/pathmind-webapp/frontend/styles/views/experiment-view.css
+++ b/pathmind-webapp/frontend/styles/views/experiment-view.css
@@ -100,7 +100,7 @@
 .experiment-view .metrics-wrapper span {
     display: flex;
     align-items: center;
-    flex: 1 0 auto;
+    flex: 0 0 auto;
     height: 2rem;
     line-height: 1;
     margin-left: var(--lumo-space-s);
@@ -144,6 +144,10 @@
 
 .experiment-view .metrics-wrapper {
     align-items: flex-end;
+}
+
+.experiment-view .observations-panel {
+    max-height: 27rem;
 }
 
 .experiment-view .observations-table {


### PR DESCRIPTION
#### Changes
- [x] do not allow metrics to grow in extra space
- [x] set max height to observations panel

#### PR Screenshot
This is a result of DOM manipulation to replicate the UI alignment issue. There were not so many observations for this model.
![image](https://user-images.githubusercontent.com/13184582/95143618-12ba5180-07a9-11eb-8c96-882f2536e816.png)

Fixes #2123