### PR TITLE
#2220 - Event bus for policy chart & simulation metrics panel update

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
@@ -547,7 +547,7 @@ public class ExperimentView extends PathMindDefaultView implements HasUrlParamet
                 policy = PolicyUtils.selectBestPolicy(policies);
                 PushUtils.push(getUI(), () -> {
                     if (policy != null) {
-                        policyChartPanel.updateChart(policies, policy);
+                        policyChartPanel.updateChart(experiment, policy);
                     }
                     updateDetailsForExperiment();
                 });


### PR DESCRIPTION
In essence the policy chart panel was using the event's policies to update the chart rather than updating the existing list of policies. Meaning each policy update chart only showed the policies that had just been updated.