### PR TITLE
Fix cookie popup not closing issue

### DIFF
--- a/pathmind-webapp/frontend/src/components/molecules/cookie-consent-box.js
+++ b/pathmind-webapp/frontend/src/components/molecules/cookie-consent-box.js
@@ -18,16 +18,18 @@ class CookieConsentBox extends PolymerElement {
 
     ready() {
         super.ready();
-        window.cookieconsent.initialise({
-            container: document.querySelector("vaadin-app-layout"),
-            content: {
-              message: "This website uses cookies to ensure you get the best experience.",
-              dismiss: "Got it!",
-              link: "Learn more",
-              href: "https://pathmind.com/privacy"
-            },
-            position: "bottom-left",
-        });
+        if (document.querySelectorAll(".cc-window[aria-label~='cookieconsent']").length === 0) {
+            window.cookieconsent.initialise({
+                container: document.querySelector("vaadin-app-layout"),
+                content: {
+                  message: "This website uses cookies to ensure you get the best experience.",
+                  dismiss: "Got it!",
+                  link: "Learn more",
+                  href: "https://pathmind.com/privacy"
+                },
+                position: "bottom-left",
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Previously the cookie popup was attached once on every page load so there were too many cookie popups.

This PR only attaches it once.

Fixes #2346 