### PR TITLE
Remove text field from slack notification msg

### DIFF
--- a/Jenkinsfile_PRs
+++ b/Jenkinsfile_PRs
@@ -405,7 +405,6 @@ pipeline {
                     title      : "Test_PRs » Build #${env.BUILD_NUMBER} - Failed",
                     title_link : "${env.BUILD_URL}",
                     color      : "#CF0000",
-                    text       : "<@UGH39HL4E>",
                     "mrkdwn_in": ["fields"],
                     fields     : [
                         [


### PR DESCRIPTION
Remove text field from slack notification msg to stop pinging in slack