### PR TITLE
introduce docker multistep build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN mvn package -Pproduction
 # Step 2: copy only jar to minimized zulu container
 FROM azul/zulu-openjdk-alpine:11
 COPY --from=webapp-build /app/pathmind-webapp/target/pathmind-webapp-0.0.1-SNAPSHOT.jar /app/pathmind-webapp/target/pathmind-webapp-0.0.1-SNAPSHOT.jar
+COPY --from=webapp-build /app/pathmind-updater/target/pathmind-updater-0.0.1-SNAPSHOT.jar /app/pathmind-updater/target/pathmind-updater-0.0.1-SNAPSHOT.jar
 EXPOSE 80
 CMD ["java", "-Xmx4096m", "-XX:+UseG1GC", "-Dvaadin.productionMode", "-jar", "/app/pathmind-webapp/target/pathmind-webapp-0.0.1-SNAPSHOT.jar", "--server.port=80"]


### PR DESCRIPTION
Here is a multistep Docker build for web-app. 
Currently, our web-app container has everything that is used to build the jar, like Debian, maven, all the jar files in ~/.m2/ folder.

By this PR output of the docker build contains only executable webapp jar inside of minimized zulu on alpine java container. 

Size should be dramatically reduced.
