### PR TITLE
Remove GA script

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/login/PublicView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/login/PublicView.java
@@ -15,7 +15,7 @@ public interface PublicView extends HasDynamicTitle, PageConfigurator {
     default void configurePage(InitialPageSettings settings) {
         PageConfigurationUtils.defaultPageConfiguration(settings);
         settings.addInlineWithContents(InitialPageSettings.Position.PREPEND,
-                        "<script src=\"https://www.googleoptimize.com/optimize.js?id=GTM-T2DSBKT\"></script>", InitialPageSettings.WrapMode.NONE);
+                "<script src=\"https://www.googleoptimize.com/optimize.js?id=GTM-T2DSBKT\"></script>", InitialPageSettings.WrapMode.NONE);
         settings.addInlineWithContents(InitialPageSettings.Position.PREPEND,
                 "<style>.async-hide { opacity: 0 !important} </style><script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;" +
                         "h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};" +


### PR DESCRIPTION
On this branch, there's only 1 GA script attached to the `<head></head>` (from Segment)
![image](https://user-images.githubusercontent.com/13184582/100031856-9dc2da00-2e31-11eb-907d-f5b475678d14.png)

On dev, there are 2 GA scripts. One from Segment and the other from `PublicView.java`
![image](https://user-images.githubusercontent.com/13184582/100031894-b59a5e00-2e31-11eb-9107-a06178147ced.png)

The new setup on this branch passed the checking on Google Optimize editor
![image](https://user-images.githubusercontent.com/13184582/100032010-f4301880-2e31-11eb-9090-139cc8b04333.png)

Closes #2463 
