### PR TITLE
#2506 - Fixed bug: Experiment view showing unknown data from another experiment

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/EventBusSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/EventBusSubscriber.java
@@ -61,10 +61,10 @@ public abstract class EventBusSubscriber<T extends PathmindBusEvent> {
     }
 
     public boolean isSourceSameUI(T event) {
-        if (event.getSourceId() < 0 || uiSupplier.get().isEmpty()) {
+        if (event.getSourceUI() == null || uiSupplier.get().isEmpty()) {
             return false;
         }
-        return event.getSourceId() == uiSupplier.get().get().getUIId();
+        return event.getSourceUI().equals(uiSupplier.get().get());
     }
 
     public Supplier<Optional<UI>> getUiSupplier() {

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/PathmindBusEvent.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/bus/PathmindBusEvent.java
@@ -8,10 +8,7 @@ public interface PathmindBusEvent {
 
     BusEventType getEventType();
 
-    default int getSourceId() {
-        if (UI.getCurrent() == null) {
-            return -1;
-        }
-        return UI.getCurrent().getUIId();
+    default UI getSourceUI() {
+        return UI.getCurrent();
     }
 }


### PR DESCRIPTION
Closes #2506,

Below is a copy and paste of my last comment in the ticket:

This issue was tricky and could only occur if multiple people were using system at the same time, had opened exactly the same number of pages (views) within the system and on top of that switched to a different experiment while both where on the experiment view. In other words a combination of sequences and steps had to occur over which is why we probably haven't seen it before.

To replicate the issue you can log into the system on two different browsers and then make sure to follow the exact same steps, exact same clicks, everything, on both browsers. Any single change in steps, including a page refresh, will cause it to not work. When you get to the experiment view (again using the very exact same steps) switch to another experiment and you'll see the other browser also switch to that same experiment. However if you even do just a single page refresh on the other browser then everything is fine and no bug. To get it to happen a second time you then have to get the browsers to sync up perfectly, that is the same number of views have to have been loaded and on top of that they both need to be on the experiment view, and again switch experiments. It's a lot easier to do when initially logging in because once the steps are out of sync it gets very hard trying to get them back in sync to replicate the bug. Hence why it's so rare. The more actions the less likely the issue is to appear.

The issue was how the eventbus filtered the current view and not the eventbus itself. Meaning regardless if we used our own custom eventbus or an open source one we would still have this same issue. Specifically the issue is how the filter knew that you were still on the same screen (view). That filter has to be defined by us. That's why this issue was not with the eventbus but with the filter.

That being said I had confirmed at one point with Henri that each view has their own unique ID and you could get that through the UI with UI.getCurrent().getUIId() however that was either incorrect (miscommunication somewhere) or it has changed in one of the vaadin updates since it was implemented because the code had been reviewed by one of the vaadin consultants. In any case I also confirmed tonight that it wasn't due to the recent vaadin update to 14.4.3 so if there was a miscommunication then it would've had to have been due to a previous vaadin update if it's a change in the vaadin behavior. Either way the fact that no one encountered until now is an indication of how infrequent it has been , however as more users use the system the odds increase and so we need to resolve this asap.

The solution is that instead of comparing the UI.getUIId() I'm now comparing the UI instance directly. Although it's not a comparison of the view ID the effect is the same because a UI instance is created for every browser tab. And since there's is a UI per tab it's impossible to be on two different views in the same browser tab at the same time, meaning it works the same as confirming the views are the same. I basically changed how we define whether or not two views/pages are the same by comparing the instances rather than the ID's as the ID's can be reused over multiple browser tabs.