### PR TITLE
Add Segment track events to links on empty projects view

### DIFF
--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/segment/SegmentTrackingEvents.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/segment/SegmentTrackingEvents.java
@@ -7,6 +7,8 @@ public class SegmentTrackingEvents {
     public static final String EVENT_VERIFY_EMAIL = "Email Verified";
     public static final String EVENT_LOGIN = "Signed in";
     public static final String EVENT_IMPORT_MODEL = "Model Uploaded";
+    public static final String EVENT_ONBOARDING_TUTORIAL = "Onboarding Tutorial Link Clicked";
+    public static final String EVENT_ONBOARDING_ZIP = "Onboarding Download Zip Link Clicked";
     public static final String EVENT_CREATE_FIRST_PROJECT = "Create First Project Button Clicked";
     public static final String EVENT_CREATE_PROJECT = "Project Created";
     public static final String EVENT_START_TRAINING = "Training Started";

--- a/pathmind-webapp/frontend/src/dashboard/empty-dashboard-placeholder.js
+++ b/pathmind-webapp/frontend/src/dashboard/empty-dashboard-placeholder.js
@@ -48,12 +48,12 @@ class EmptyDashboardPlaceholder extends PolymerElement {
                 <vaadin-vertical-layout>
                     <h3>Using AI may be easier than you think:</h3>
                     <ul>
-                        <li>Upload a zip file of the simulation model to Pathmind. <a href="https://s3.amazonaws.com/public-pathmind.com/SimpleStochasticPathmindDemo.zip" download>Download zip file</a></li>
+                        <li>Upload a zip file of the simulation model to Pathmind. <a id="zipLink" href="https://s3.amazonaws.com/public-pathmind.com/SimpleStochasticPathmindDemo.zip" download>Download zip file</a></li>
                         <li>Write a reward function (It's simple, just copy and paste this: reward = after.goalReached - 0.1; ).</li>
                         <li>Once training is complete, click on “Export Policy”.</li>
                         <li>Load the trained AI into AnyLogic to see it perform.</li>
                     </ul>
-                    <i>(For more detailed information, please see <a href="http://help.pathmind.com/en/articles/4540076-getting-started-with-simple-stochastic" target="_blank">our tutorial</a>.)</i>
+                    <i>(For more detailed information, please see <a id="tutorialLink" href="http://help.pathmind.com/en/articles/4540076-getting-started-with-simple-stochastic" target="_blank">our tutorial</a>.)</i>
                 </vaadin-vertical-layout>
                 <vaadin-horizontal-layout>
                     <a class="button-link" id="newProjectButton" router-link href="newProject">Create Your First Project Now</a>

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/plugins/SegmentIntegrator.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/plugins/SegmentIntegrator.java
@@ -32,6 +32,8 @@ import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_EXP
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_IMPORT_MODEL;
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_LOGIN;
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_NEW_EXPERIMENT;
+import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_ONBOARDING_TUTORIAL;
+import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_ONBOARDING_ZIP;
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_RESTART_TRAINING;
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_SAVE_EXPERIMENT_DRAFT;
 import static io.skymind.pathmind.shared.segment.SegmentTrackingEvents.EVENT_SAVE_MODEL_DRAFT;
@@ -98,6 +100,14 @@ public class SegmentIntegrator extends PolymerTemplate<SegmentIntegrator.Model> 
         JsonObject additionalInfo = Json.createObject();
         additionalInfo.put("result", result ? "success" : "failed");
         track(EVENT_IMPORT_MODEL, additionalInfo);
+    }
+
+    public void onboardingTutorialClicked() {
+        track(EVENT_ONBOARDING_TUTORIAL);
+    }
+
+    public void onboardingZipDownloaded() {
+        track(EVENT_ONBOARDING_ZIP);
     }
 
     public void createFirstProject() {

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/dashboard/components/EmptyDashboardPlaceholder.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/dashboard/components/EmptyDashboardPlaceholder.java
@@ -11,10 +11,23 @@ import io.skymind.pathmind.webapp.ui.plugins.SegmentIntegrator;
 @Tag("empty-dashboard-placeholder")
 @JsModule("./src/dashboard/empty-dashboard-placeholder.js")
 public class EmptyDashboardPlaceholder extends PolymerTemplate<TemplateModel> {
+
+    @Id("zipLink")
+    private Anchor zipLink;
+
+    @Id("tutorialLink")
+    private Anchor tutorialLink;
+
     @Id("newProjectButton")
     private Anchor newProjectButton;
 
     public EmptyDashboardPlaceholder(SegmentIntegrator segmentIntegrator) {
+        zipLink.getElement().addEventListener("click", click -> {
+            segmentIntegrator.onboardingZipDownloaded();
+        });
+        tutorialLink.getElement().addEventListener("click", click -> {
+            segmentIntegrator.onboardingTutorialClicked();
+        });
         newProjectButton.getElement().addEventListener("click", click -> {
             segmentIntegrator.createFirstProject();
         });


### PR DESCRIPTION
Open your dev console, then click the links.
![image](https://user-images.githubusercontent.com/13184582/100813937-7bf1d480-347b-11eb-95ce-b6783a06f75e.png)

After clicking the links, you should see these on your Chrome dev tools:
![image](https://user-images.githubusercontent.com/13184582/101119509-6f5daf80-3626-11eb-9925-d0c751c1a3f6.png)
![image](https://user-images.githubusercontent.com/13184582/101119487-653bb100-3626-11eb-9b9e-47002bad8a14.png)

Closes #2505 