### PR TITLE
#2536 - Improve the performance when switching experiments.

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/NewExperimentView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/NewExperimentView.java
@@ -66,6 +66,7 @@ import io.skymind.pathmind.webapp.ui.views.experiment.components.observations.su
 import io.skymind.pathmind.webapp.ui.views.experiment.components.rewardFunction.RewardFunctionEditor;
 import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.main.NewExperimentViewExperimentStartTrainingSubscriber;
 import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.view.NewExperimentViewExperimentChangedViewSubscriber;
+import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.view.NewExperimentViewExperimentSwitchedViewSubscriber;
 import io.skymind.pathmind.webapp.ui.views.experiment.utils.ExperimentCapLimitVerifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -143,7 +144,8 @@ public class NewExperimentView extends PathMindDefaultView implements HasUrlPara
         EventBus.subscribe(this, getUISupplier(),
                 new NewExperimentViewExperimentStartTrainingSubscriber(this),
                 new NewExperimentViewExperimentChangedViewSubscriber(this),
-                new ObservationsPanelExperimentSwitchedViewSubscriber(observationDAO, observationsPanel));
+                new NewExperimentViewExperimentSwitchedViewSubscriber(this),
+        new ObservationsPanelExperimentSwitchedViewSubscriber(observationDAO, observationsPanel));
     }
 
     @Override

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/main/ExperimentViewPolicyUpdateSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/main/ExperimentViewPolicyUpdateSubscriber.java
@@ -16,19 +16,12 @@ public class ExperimentViewPolicyUpdateSubscriber extends PolicyUpdateSubscriber
 
     @Override
     public void handleBusEvent(PolicyUpdateBusEvent event) {
-        synchronized (experimentView.getExperimentLock()) {
-            // Need a check in case the experiment was on hold waiting for the change of experiment to load
-            if (event.getExperimentId() != event.getExperimentId()) {
-                return;
-            }
-            // Update or insert the policy in experiment.getPolicies
-            ExperimentUtils.addOrUpdatePolicies(experimentView.getExperiment(), event.getPolicies());
-            // This is needed for other subscriber updates that rely on the best policy being updated.
-            experimentView.setBestPolicy(PolicyUtils.selectBestPolicy(experimentView.getExperiment().getPolicies()).orElse(null));
-
-            // REFACTOR -> This method is currently overloaded and does too much but that is for another PR.
-            experimentView.updateDetailsForExperiment();
-        }
+        // Update or insert the policy in experiment.getPolicies
+        ExperimentUtils.addOrUpdatePolicies(experimentView.getExperiment(), event.getPolicies());
+        // This is needed for other subscriber updates that rely on the best policy being updated.
+        experimentView.setBestPolicy(PolicyUtils.selectBestPolicy(experimentView.getExperiment().getPolicies()).orElse(null));
+        // REFACTOR -> This method is currently overloaded and does too much but that is for another PR.
+        experimentView.updateDetailsForExperiment();
     }
 
     @Override

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/view/ExperimentViewExperimentSwitchedViewSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/view/ExperimentViewExperimentSwitchedViewSubscriber.java
@@ -1,0 +1,26 @@
+package io.skymind.pathmind.webapp.ui.views.experiment.subscribers.view;
+
+import io.skymind.pathmind.webapp.bus.events.view.ExperimentSwitchedViewBusEvent;
+import io.skymind.pathmind.webapp.bus.subscribers.view.ExperimentSwitchedViewSubscriber;
+import io.skymind.pathmind.webapp.ui.views.experiment.ExperimentView;
+
+public class ExperimentViewExperimentSwitchedViewSubscriber extends ExperimentSwitchedViewSubscriber {
+
+    private ExperimentView experimentView;
+
+    public ExperimentViewExperimentSwitchedViewSubscriber(ExperimentView experimentView) {
+        super();
+        this.experimentView = experimentView;
+    }
+
+    @Override
+    public void handleBusEvent(ExperimentSwitchedViewBusEvent event) {
+        experimentView.setExperiment(event.getExperiment());
+    }
+
+    @Override
+    public boolean filterBusEvent(ExperimentSwitchedViewBusEvent event) {
+        // We only need to load the experiment if the experiment we're switching to is NOT a draft experiment.
+        return !event.getExperiment().isDraft();
+    }
+}

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/view/NewExperimentViewExperimentSwitchedViewSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/view/NewExperimentViewExperimentSwitchedViewSubscriber.java
@@ -1,0 +1,25 @@
+package io.skymind.pathmind.webapp.ui.views.experiment.subscribers.view;
+
+import io.skymind.pathmind.webapp.bus.events.view.ExperimentSwitchedViewBusEvent;
+import io.skymind.pathmind.webapp.bus.subscribers.view.ExperimentSwitchedViewSubscriber;
+import io.skymind.pathmind.webapp.ui.views.experiment.NewExperimentView;
+
+public class NewExperimentViewExperimentSwitchedViewSubscriber extends ExperimentSwitchedViewSubscriber {
+
+    private NewExperimentView newExperimentView;
+
+    public NewExperimentViewExperimentSwitchedViewSubscriber(NewExperimentView newExperimentView) {
+        this.newExperimentView = newExperimentView;
+    }
+
+    @Override
+    public void handleBusEvent(ExperimentSwitchedViewBusEvent event) {
+        newExperimentView.setExperiment(event.getExperiment());
+    }
+
+    @Override
+    public boolean filterBusEvent(ExperimentSwitchedViewBusEvent event) {
+        // We only need to load the experiment if the experiment we're switching to is a draft experiment.
+        return event.getExperiment().isDraft();
+    }
+}


### PR DESCRIPTION
Closes #2536. This is an additional performance improvement similar to #2525 that removes full page reloads that are no longer required.