### PR TITLE
Use server timezone for datetime calculation

### DIFF
--- a/pathmind-webapp/frontend/src/components/atoms/datetime-display.js
+++ b/pathmind-webapp/frontend/src/components/atoms/datetime-display.js
@@ -11,14 +11,22 @@ class DatetimeDisplay extends PolymerElement {
             datetime: {
                 type: String,
             },
+            datetimeWithTimezone: {
+                type: String,
+                computed: `_computeDatetimeWithTimezone(datetime, serverTimeZoneOffsetFromUTC)`,
+            },
             date: {
                 type: String,
-                computed: `_computeDate(datetime)`,
+                computed: `_computeDate(datetimeWithTimezone)`,
                 observer: `_createTooltip`,
             },
             displaytext: {
                 type: String,
-                computed: `_computeDisplayText(datetime)`,
+                computed: `_computeDisplayText(datetimeWithTimezone)`,
+            },
+            serverTimeZoneOffsetFromUTC: {
+                type: String,
+                value: "",
             },
         }
     }
@@ -51,8 +59,8 @@ class DatetimeDisplay extends PolymerElement {
         register('my-locale', this.localeFunc);
     }
 
-    _computeDate(datetime) {
-        return new Date(datetime).toLocaleDateString(window.navigator.language, { 
+    _computeDate(dateTimeWithTimezone) {
+        return new Date(dateTimeWithTimezone).toLocaleDateString(window.navigator.language, { 
             year: 'numeric', 
             month: 'short', 
             day: 'numeric', 
@@ -61,7 +69,7 @@ class DatetimeDisplay extends PolymerElement {
 
     _createTooltip() {
         const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        this.title = new Date(this.datetime).toLocaleString(window.navigator.language, { 
+        this.title = new Date(this.datetimeWithTimezone).toLocaleString(window.navigator.language, { 
             weekday: 'short', 
             year: 'numeric', 
             month: 'short', 
@@ -73,8 +81,13 @@ class DatetimeDisplay extends PolymerElement {
         });
     }
 
-    _computeDisplayText(datetime) {
-        return new Date(datetime) <= new Date().setDate(new Date().getDate()-30) ? this.date : format(datetime, 'my-locale');
+    _computeDatetimeWithTimezone(datetime, timezone) {
+        return datetime+timezone;
+    }
+
+    _computeDisplayText(dateTimeWithTimezone) {
+        const datetimeAsDate = new Date(dateTimeWithTimezone);
+        return datetimeAsDate <= new Date().setDate(new Date().getDate()-30) ? this.date : format(datetimeAsDate.getTime(), 'my-locale');
     }
 }
 

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/atoms/DatetimeDisplay.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/atoms/DatetimeDisplay.java
@@ -1,6 +1,7 @@
 package io.skymind.pathmind.webapp.ui.components.atoms;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
@@ -17,9 +18,18 @@ public class DatetimeDisplay extends PolymerTemplate<DatetimeDisplay.Model> impl
     public DatetimeDisplay(LocalDateTime datetime) {
         super();
         getModel().setDatetime(datetime.toString());
+        getModel().setServerTimeZoneOffsetFromUTC(calculateTimeZoneOffset());
+    }
+
+    private String calculateTimeZoneOffset() {
+        LocalDateTime now = LocalDateTime.now();
+        ZoneId serverTimeZone = ZoneId.systemDefault();
+        return serverTimeZone.getRules().getOffset(now).toString();
     }
 
     public interface Model extends TemplateModel {
         void setDatetime(String datetime);
+
+        void setServerTimeZoneOffsetFromUTC(String serverTimeZoneOffsetFromUTC);
     }
 }


### PR DESCRIPTION
#### Bug details
Currently on dev/prod, after you create an Experiment, you can sometimes see "in 20 minutes ago" after some time, or "4 hours ago" right after creation. It's because the time string was based on server time, but the time zone was based on the user's browser. This time zone mismatch caused the time to be inaccurate. You can reproduce the issue locally on dev branch by running the webapp, and then change your computer's time zone while browsing the site.

Fixes #2544 