### PR TITLE
remove autotest users

### DIFF
--- a/pathmind-database/src/main/resources/db/changelog/db.initial.xml
+++ b/pathmind-database/src/main/resources/db/changelog/db.initial.xml
@@ -1887,4 +1887,10 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="2340-01" author="alexander.makarov@toptal.com">
+        <delete tableName="pathmind_user">
+            <where>firstname='Evgeniy' and lastname='Autotest'</where>
+        </delete>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
```
[INFO] DELETE FROM pathmind_user WHERE firstname='Evgeniy' and lastname='Autotest'
[INFO] Data deleted from pathmind_user
[INFO] ChangeSet db.initial.xml::2340-01::alexander.makarov@toptal.com ran successfully in 91ms
```

fix #2340