### PR TITLE
Dev-2706 - Several experiment archived enhancements and bug fixes

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
@@ -29,6 +29,7 @@ import io.skymind.pathmind.webapp.ui.views.experiment.components.experimentNotes
 import io.skymind.pathmind.webapp.ui.views.experiment.components.notification.StoppedTrainingNotification;
 import io.skymind.pathmind.webapp.ui.views.experiment.components.simulationMetrics.SimulationMetricsPanel;
 import io.skymind.pathmind.webapp.ui.views.experiment.components.trainingStatus.TrainingStatusDetailsPanel;
+import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.main.experiment.ExperimentViewComparisonExperimentArchivedSubscriber;
 import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.main.experiment.ExperimentViewPolicyUpdateSubscriber;
 import io.skymind.pathmind.webapp.ui.views.experiment.subscribers.main.experiment.ExperimentViewRunUpdateSubscriber;
 import lombok.extern.slf4j.Slf4j;
@@ -103,10 +104,11 @@ public class ExperimentView extends AbstractExperimentView {
         showCompareExperimentComponents(isComparisonMode);
     }
 
-    private void leaveComparisonMode() {
+    public void leaveComparisonMode() {
         isComparisonMode = false;
         removeClassName("comparison-mode");
         showCompareExperimentComponents(isComparisonMode);
+        getElement().executeJs("window.dispatchEvent(new Event('resize'))");
     }
 
     public Experiment getComparisonExperiment() {
@@ -126,7 +128,12 @@ public class ExperimentView extends AbstractExperimentView {
     protected List<EventBusSubscriber> getViewSubscribers() {
         return List.of(
                 new ExperimentViewPolicyUpdateSubscriber(this, experimentDAO),
-                new ExperimentViewRunUpdateSubscriber(this, experimentDAO));
+                new ExperimentViewRunUpdateSubscriber(this, experimentDAO),
+                new ExperimentViewComparisonExperimentArchivedSubscriber(this));
+    }
+
+    public boolean isComparisonMode() {
+        return isComparisonMode;
     }
 
     @Override
@@ -169,7 +176,6 @@ public class ExperimentView extends AbstractExperimentView {
     private VerticalLayout getComparisonExperimentPanel() {
         FloatingCloseButton comparisonModeCloseButton = new FloatingCloseButton("Exit Comparison Mode", () -> {
             leaveComparisonMode();
-            getElement().executeJs("window.dispatchEvent(new Event('resize'))");
         });
         VerticalLayout comparisonComponents = WrapperUtils.wrapVerticalWithNoPaddingOrSpacingAndWidthAuto(
             WrapperUtils.wrapCenterAlignmentFullSplitLayoutHorizontal(

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/narbarItem/action/NavBarItemArchiveExperimentAction.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/narbarItem/action/NavBarItemArchiveExperimentAction.java
@@ -1,18 +1,35 @@
 package io.skymind.pathmind.webapp.ui.views.experiment.components.narbarItem.action;
 
 import io.skymind.pathmind.shared.data.Experiment;
+import io.skymind.pathmind.shared.utils.ExperimentUtils;
 import io.skymind.pathmind.webapp.data.utils.ExperimentGuiUtils;
 import io.skymind.pathmind.webapp.ui.utils.ConfirmationUtils;
 import io.skymind.pathmind.webapp.ui.views.experiment.AbstractExperimentView;
+import io.skymind.pathmind.webapp.ui.views.experiment.ExperimentView;
 import io.skymind.pathmind.webapp.ui.views.experiment.components.navbar.ExperimentsNavBar;
 
 public class NavBarItemArchiveExperimentAction {
     public static void archiveExperiment(Experiment experiment, ExperimentsNavBar experimentsNavBar, AbstractExperimentView abstractExperimentView) {
         ConfirmationUtils.archive("Experiment #" + experiment.getName(), () -> {
             synchronized (abstractExperimentView.getExperimentLock()) {
+
+                // Archive the experiment.
                 ExperimentGuiUtils.archiveExperiment(abstractExperimentView.getExperimentDAO(), experiment, true);
                 abstractExperimentView.getSegmentIntegrator().archived(Experiment.class, true);
-                ExperimentGuiUtils.navigateToFirstUnarchivedOrModel(abstractExperimentView.getUISupplier(), experimentsNavBar.getExperiments());
+
+                // If it's the same then navigate to next unarchived otherwise update the navbar.
+                if(ExperimentUtils.isSameExperiment(experiment, abstractExperimentView.getExperiment())) {
+                    ExperimentGuiUtils.navigateToFirstUnarchivedOrModel(abstractExperimentView.getUISupplier(), experimentsNavBar.getExperiments());
+                } else {
+                    experimentsNavBar.updateExperiment(experiment);
+                }
+
+                // Test to see if it's a comparison experiment and if so close the comparison panel.
+                if(abstractExperimentView instanceof ExperimentView &&
+                        ((ExperimentView) abstractExperimentView).isComparisonMode() &&
+                        ExperimentUtils.isSameExperiment(experiment, ((ExperimentView) abstractExperimentView).getComparisonExperiment())) {
+                    ((ExperimentView) abstractExperimentView).leaveComparisonMode();
+                }
             }
         });
     }

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/navbar/ExperimentsNavBar.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/navbar/ExperimentsNavBar.java
@@ -82,6 +82,14 @@ public class ExperimentsNavBar extends VerticalLayout {
         return modelId;
     }
 
+    public void updateExperiment(Experiment experiment) {
+        if (experiment.isArchived()) {
+            removeExperiment(experiment);
+        } else {
+            addExperiment(experiment);
+        }
+    }
+
     public void removeExperiment(Experiment experiment) {
         List<ExperimentsNavBarItem> toRemoveNavBarItems = experimentsNavBarItems.stream()
                 .filter(experimentsNavBarItem -> ExperimentUtils.isSameExperiment(experimentsNavBarItem.getExperiment(), experiment))

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/navbar/subscribers/main/NavBarExperimentArchivedSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/navbar/subscribers/main/NavBarExperimentArchivedSubscriber.java
@@ -17,11 +17,7 @@ public class NavBarExperimentArchivedSubscriber extends ExperimentArchivedSubscr
     // We can ignore this code for archived experiments since the navbar is not visible for archived experiments.
     @Override
     public void handleBusEvent(ExperimentArchivedBusEvent event) {
-        if (event.getExperiment().isArchived()) {
-            experimentsNavBar.removeExperiment(event.getExperiment());
-        } else {
-            experimentsNavBar.addExperiment(event.getExperiment());
-        }
+        experimentsNavBar.updateExperiment(event.getExperiment());
     }
 
     @Override

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/main/experiment/ExperimentViewComparisonExperimentArchivedSubscriber.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/subscribers/main/experiment/ExperimentViewComparisonExperimentArchivedSubscriber.java
@@ -1,0 +1,35 @@
+package io.skymind.pathmind.webapp.ui.views.experiment.subscribers.main.experiment;
+
+import io.skymind.pathmind.shared.utils.ExperimentUtils;
+import io.skymind.pathmind.webapp.bus.events.main.ExperimentArchivedBusEvent;
+import io.skymind.pathmind.webapp.bus.subscribers.main.ExperimentArchivedSubscriber;
+import io.skymind.pathmind.webapp.ui.utils.NotificationUtils;
+import io.skymind.pathmind.webapp.ui.views.experiment.ExperimentView;
+
+public class ExperimentViewComparisonExperimentArchivedSubscriber extends ExperimentArchivedSubscriber {
+
+    private ExperimentView experimentView;
+
+    public ExperimentViewComparisonExperimentArchivedSubscriber(ExperimentView experimentView) {
+        this.experimentView = experimentView;
+    }
+
+    @Override
+    public void handleBusEvent(ExperimentArchivedBusEvent event) {
+        NotificationUtils.alertAndThen(getUiSupplier(),
+                "Comparison Experiment Archived",
+                "The comparison experiment was archived.",
+                ui -> experimentView.leaveComparisonMode());
+    }
+
+    @Override
+    public boolean filterBusEvent(ExperimentArchivedBusEvent event) {
+        // We only want to filter if it's for the comparisonExperiment, it's in comparison mode, and if
+        // the experiment is going to be archived (unarchiving would mean it was not possible to display it).
+        // The isSameExperiment() comparison must be last because we have to first be comparisonMode to even
+        // have a comparisonExperiment.
+        return experimentView.isComparisonMode() &&
+                event.getExperiment().isArchived() &&
+                ExperimentUtils.isSameExperiment(event.getExperiment(), experimentView.getComparisonExperiment());
+    }
+}


### PR DESCRIPTION
This closes #2706.

The biggest fix is that if you archive another experiment that is not the current it should not navigate to the next available experiment but instead should stay on the page. After that I've added listeners and better handling if the comparison experiment is archived, as in it will close the comparison.