### PR TITLE
change name in punctuator release

### DIFF
--- a/infra/helm/pathmind/values_dev-punctuator.yaml
+++ b/infra/helm/pathmind/values_dev-punctuator.yaml
@@ -45,7 +45,7 @@ readinessprobe: {}
 
 livenessprobe: {}
 
-name: pathmind-updater
+name: pathmind-punctuator
 
 namespace: dev
 

--- a/infra/helm/pathmind/values_prod-punctuator.yaml
+++ b/infra/helm/pathmind/values_prod-punctuator.yaml
@@ -45,7 +45,7 @@ readinessprobe: {}
 
 livenessprobe: {}
   
-name: pathmind-updater
+name: pathmind-punctuator
 
 namespace: default
 

--- a/infra/helm/pathmind/values_staging-punctuator.yaml
+++ b/infra/helm/pathmind/values_staging-punctuator.yaml
@@ -45,7 +45,7 @@ readinessprobe: {}
 
 livenessprobe: {}
 
-name: pathmind-updater
+name: pathmind-punctuator
 
 namespace: staging
 

--- a/infra/helm/pathmind/values_test-punctuator.yaml
+++ b/infra/helm/pathmind/values_test-punctuator.yaml
@@ -45,7 +45,7 @@ readinessprobe: {}
 
 livenessprobe: {}
 
-name: pathmind-updater
+name: pathmind-punctuator
 
 namespace: test
 


### PR DESCRIPTION
Changing the name of the release, as per the [error message](https://jenkins.dev.devpathmind.com/job/pathmind-webapp/job/dev/629/console#main-panel:~:text=annotation%20validation%20error%3A%20key%20%22meta.helm.sh%2Frelease%2Dname%22%20must,equal%20%22pathmind%2Dpunctuator%22%3A%20current%20value%20is%20%22pathmind%2Dupdater%22)
 