### PR TITLE
Add selenium cleanup

### DIFF
--- a/infra/images/jenkins/Dockerfile
+++ b/infra/images/jenkins/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && \
 COPY junit/* /usr/bin/
 
 #crontab
+COPY selenium_cleanup.sh /tmp/selenium_cleanup.sh
 COPY crontab /tmp/crontab
 RUN crontab /tmp/crontab
 RUN cat /usr/local/bin/jenkins.sh | awk 'NR==2 {print "service cron start"} 1' > /tmp/tmp && mv /tmp/tmp /usr/local/bin/jenkins.sh && chmod +x /usr/local/bin/jenkins.sh

--- a/infra/images/jenkins/crontab
+++ b/infra/images/jenkins/crontab
@@ -1,3 +1,4 @@
 0 0 * * * find /var/jenkins_home/ -maxdepth 1 -mtime +3 -type d | grep '/native' | xargs -I {} rm -rf {}
 0 0 * * * find /var/jenkins_home/ -maxdepth 1 -mtime +3 -type d | grep '/[0-9]' | xargs -I {} rm -rf {}
 0 0 * * * find /var/jenkins_home/jobs/Test_PRs/builds/ -maxdepth 1 -mtime +3 -type d | grep '/[0-9]' | xargs -I {} rm -rf {}
+0 * * * * bash /tmp/selenium_cleanup.sh

--- a/infra/images/jenkins/selenium_cleanup.sh
+++ b/infra/images/jenkins/selenium_cleanup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+#Clean old namesapces
+
+for ns in `kubectl get ns | grep '^[0-9]' | awk '{print $1}'`
+do
+    kubectl get all -n $ns | grep pathmind > /dev/null
+    if [ $? != 0 ]
+    then
+        kubectl get all -n $ns | grep selenium > /dev/null
+        if [ $? == 0 ]
+        then
+            kubectl delete ns $ns
+        fi
+    fi
+done


### PR DESCRIPTION
Sometimes when PR's fail unexpectedly some garbage is left in kubernetes, the purpose of this is to clean them.