### PR TITLE
temporarily use Ray 1.0.0

### DIFF
--- a/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
+++ b/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
@@ -529,7 +529,7 @@ public class AWSExecutionProvider implements ExecutionProvider {
                 var("MAIN_AGENT", job.getMainAgentName()),
                 var("EXPERIMENT_CLASS", job.getExpClassName()),
                 var("EXPERIMENT_TYPE", job.getExpClassType()),
-                var("FREEZING", String.valueOf(Boolean.TRUE))
+                var("FREEZING", String.valueOf(Boolean.FALSE))
         ));
 
         if (job.getEnvironment() != null) {

--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/environment/ExecutionEnvironmentManager.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/environment/ExecutionEnvironmentManager.java
@@ -22,7 +22,7 @@ public class ExecutionEnvironmentManager {
                 PathmindHelper.VERSION_1_4_0,
                 NativeRL.VERSION_1_5_0,
                 JDK.VERSION_8_222,
-                Conda.VERSION_1_2_0,
+                Conda.VERSION_1_0_0,
                 EC2InstanceType.IT_36CPU_72GB,
                 0,
                 0,

--- a/pathmind-updater/updater/src/main/java/io/skymind/pathmind/updater/UpdaterService.java
+++ b/pathmind-updater/updater/src/main/java/io/skymind/pathmind/updater/UpdaterService.java
@@ -333,15 +333,16 @@ public class UpdaterService {
                             .collect(Collectors.toList())
             );
 
-            if (policiesInfo.size() > 0) {
-                final byte[] policyFile = provider.policy(jobHandle, "freezing");
-                if (policiesInfo != null) {
-                    PolicyUpdateInfo policyUpdateInfo = new PolicyUpdateInfo();
-                    policyUpdateInfo.setName("freezing");
-                    policyUpdateInfo.setPolicyFile(policyFile);
-                    policiesInfo.add(policyUpdateInfo);
-                }
-            }
+            // todo we should uncomment below code later. this is only for temporarily support ray 1.0.0
+//            if (policiesInfo.size() > 0) {
+//                final byte[] policyFile = provider.policy(jobHandle, "freezing");
+//                if (policiesInfo != null) {
+//                    PolicyUpdateInfo policyUpdateInfo = new PolicyUpdateInfo();
+//                    policyUpdateInfo.setName("freezing");
+//                    policyUpdateInfo.setPolicyFile(policyFile);
+//                    policiesInfo.add(policyUpdateInfo);
+//                }
+//            }
         }
         return policiesInfo;
     }


### PR DESCRIPTION
- use Ray 1.0.0 instead 1.2.0 until we fix skip() issue.
- turn off freezing, we need to test it more.