### PR TITLE
add health endpoint to all running modules

### DIFF
--- a/pathmind-api/pom.xml
+++ b/pathmind-api/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/pathmind-api/src/main/java/io/skymind/pathmind/api/conf/WebSecurityConfig.java
+++ b/pathmind-api/src/main/java/io/skymind/pathmind/api/conf/WebSecurityConfig.java
@@ -44,6 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authenticationEntryPoint(authenticationFailureHandlerEntryPoint)
                 .and()
                 .authorizeRequests()
+                .antMatchers("/actuator/health").permitAll()
                 .antMatchers("/stripe-webhook").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/pathmind-shared/src/main/resources/shared.properties
+++ b/pathmind-shared/src/main/resources/shared.properties
@@ -106,3 +106,7 @@ pm.api.key-validity-duration=${PM_API_KEY_VALIDITY:P900D}
 pm.allowed_run_no_verified=${PM_ALLOWED_RUNS_NO_VERIFIED:1}
 
 pathmind.toggle.example-projects=${PM_TOGGLE_EXAMPLES:true}
+
+management.server.port=${server.port}
+management.endpoints.enabled-by-default=false
+management.endpoint.health.enabled=true

--- a/pathmind-updater/punctuator/pom.xml
+++ b/pathmind-updater/punctuator/pom.xml
@@ -11,6 +11,28 @@
     <artifactId>pathmind-punctuator</artifactId>
     <name>Pathmind Punctuator</name>
 
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/pathmind-updater/punctuator/src/main/resources/application.properties
+++ b/pathmind-updater/punctuator/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.main.web-application-type=none
+server.port=9902
 
 spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.jackson.default-property-inclusion=non_null

--- a/pathmind-updater/updater/pom.xml
+++ b/pathmind-updater/updater/pom.xml
@@ -11,6 +11,27 @@
     <artifactId>pathmind-updater</artifactId>
     <name>Pathmind Updater</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/pathmind-updater/updater/src/main/resources/application.properties
+++ b/pathmind-updater/updater/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.main.web-application-type=none
+server.port=9901
 
 spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.jackson.default-property-inclusion=non_null

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/security/SecurityConfiguration.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/security/SecurityConfiguration.java
@@ -140,6 +140,7 @@ public class SecurityConfiguration {
                     .antMatchers("/" + Routes.RESET_PASSWORD + Routes.WITH_PARAMETER).permitAll()
                     .antMatchers("/" + Routes.EMAIL_VERIFICATION + Routes.WITH_PARAMETER).permitAll()
                     .antMatchers("/" + Routes.VERIFICATION_EMAIL_SENT).permitAll()
+                    .antMatchers("/actuator/health").permitAll()
 
                     // Allow all flow internal requests.
                     .requestMatchers(VaadinSecurityUtils::isFrameworkInternalRequest).permitAll()

--- a/pathmind-webapp/src/main/resources/application.properties
+++ b/pathmind-webapp/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=8080
+
 pathmind.webapp.updater.rate.msec=${WEBAPP_UPDATER_RATE_MSEC:20000}
 pathmind.webapp.updater.sqs.wait.sec=${WEBAPP_UPDATER_SQS_WAIT_SEC:5}
 


### PR DESCRIPTION
Add `/actuator/health` endpoint with response as
```
{"status":"UP"}
```

The endpoint is enabled for all modules like 
web-app (:8080)
api (:8081)

Therefore updater and punctuation have to expose port:
updater (:9901)
punctuator (:9901)

fix #3030 