### PR TITLE
Add health check to updater and puctuator

### DIFF
--- a/infra/helm/pathmind/values_dev-punctuator.yaml
+++ b/infra/helm/pathmind/values_dev-punctuator.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/dev-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/dev-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-punctuator
 

--- a/infra/helm/pathmind/values_dev-updater.yaml
+++ b/infra/helm/pathmind/values_dev-updater.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/dev-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/dev-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-updater
 

--- a/infra/helm/pathmind/values_prod-punctuator.yaml
+++ b/infra/helm/pathmind/values_prod-punctuator.yaml
@@ -43,10 +43,21 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/prod-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/prod-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
-  
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
+
 name: pathmind-punctuator
 
 namespace: default

--- a/infra/helm/pathmind/values_prod-updater.yaml
+++ b/infra/helm/pathmind/values_prod-updater.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/prod-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/prod-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
   
 name: pathmind-updater
 

--- a/infra/helm/pathmind/values_staging-punctuator.yaml
+++ b/infra/helm/pathmind/values_staging-punctuator.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/staging-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/staging-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-punctuator
 

--- a/infra/helm/pathmind/values_staging-updater.yaml
+++ b/infra/helm/pathmind/values_staging-updater.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/staging-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/staging-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-updater
 

--- a/infra/helm/pathmind/values_test-punctuator.yaml
+++ b/infra/helm/pathmind/values_test-punctuator.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/test-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/test-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-punctuator
 

--- a/infra/helm/pathmind/values_test-updater.yaml
+++ b/infra/helm/pathmind/values_test-updater.yaml
@@ -43,9 +43,20 @@ env:
   SQS_UPDATER_PUNCTUATOR_QUEUE: https://sqs.us-east-1.amazonaws.com/839270835622/test-punctuator
   SQS_POLICY_SERVER_URL: https://queue.amazonaws.com/839270835622/test-policy-server.fifo
 
-readinessprobe: {}
+readinessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 10
 
-livenessprobe: {}
+livenessprobe:
+  httpGet:
+    path: /actuator/health
+    port: 9901
+  initialDelaySeconds: 30
+  periodSeconds: 15
 
 name: pathmind-updater
 


### PR DESCRIPTION
I am using the health check endpoint in Kubernetes to restart the updater or punctuator process in case it crashes.