### PR TITLE
dev-3207 change obs structure in schema.yaml

### DIFF
--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/PolicyServerService.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/PolicyServerService.java
@@ -1,17 +1,17 @@
 package io.skymind.pathmind.shared.services;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.skymind.pathmind.shared.data.Experiment;
 import io.skymind.pathmind.shared.data.Observation;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public interface PolicyServerService {
 
@@ -56,6 +56,7 @@ public interface PolicyServerService {
             private String urlPath;
         }
 
+        @JsonFormat(shape = JsonFormat.Shape.OBJECT)
         public enum ObservationType {
             INT("int"),
             INT_ARRAY("List[int]"),
@@ -71,8 +72,6 @@ public interface PolicyServerService {
 
             private final String type;
 
-            @JsonProperty("type")
-            @JsonValue
             public String getType() {
                 return this.type;
             }


### PR DESCRIPTION

https://github.com/SkymindIO/pathmind-webapp/issues/3207

This PR will change the schema from
```
---
parameters:
  discrete: false
  tuple: false
  api_key: 12345asdfg
  url_path: policy/id1234
observations:
  one: int
  three: List[float]
  two: List[int]
```
to
```
---
parameters:
  discrete: false
  tuple: false
  api_key: 12345asdfg
  url_path: policy/id1234
observations:
  one:
    type: int
  three:
    type: List[float]
  two:
    type: List[int]
```