### PR TITLE
Dev-3230 handling multiple error messages

### DIFF
--- a/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/TrainingErrorRepository.java
+++ b/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/TrainingErrorRepository.java
@@ -28,6 +28,7 @@ class TrainingErrorRepository {
     static List<String> getAllErrorsKeywords(DSLContext ctx) {
         return ctx.select(TRAINING_ERROR.KEYWORD)
                 .from(TRAINING_ERROR)
+                .orderBy(TRAINING_ERROR.ID)
                 .fetchInto(String.class);
     }
 }

--- a/pathmind-updater/updater/src/main/java/io/skymind/pathmind/updater/UpdaterService.java
+++ b/pathmind-updater/updater/src/main/java/io/skymind/pathmind/updater/UpdaterService.java
@@ -216,12 +216,11 @@ public class UpdaterService {
         final var status = jobStatus.getRunStatus();
         Collection<String> descriptions = CollectionUtils.emptyIfNull(jobStatus.getDescription());
         if (status == RunStatus.Error && !CollectionUtils.isEmpty(descriptions)) {
-            // TODO (KW): 05.02.2020 gets only first error, refactor if multiple errors scenario is possible
-            final var errorMessage = descriptions.iterator().next();
+            final var errorMessage = descriptions;
             final var allErrorsKeywords = trainingErrorDAO.getAllErrorsKeywords();
             final var knownErrorMessage = allErrorsKeywords.stream()
                     .filter(errorMessage::contains)
-                    .findAny()
+                    .findFirst()
                     .orElseGet(() -> {
                         log.warn("Unrecognized error: {}", errorMessage);
                         return UNKNOWN_ERROR_KEYWORD;


### PR DESCRIPTION
https://github.com/SkymindIO/pathmind-webapp/issues/3230

I left a comment that explains why this happens in the GitHub issue above.

before this PR,
we only care about the first line of `errors.log` 
but after this PR, we will care about the entire contents of `errors.log` but still consider the first match with all Error keywords.

![image](https://user-images.githubusercontent.com/7553831/122989586-d68b4900-d357-11eb-84ef-820a716be047.png)
http://help.pathmind.com/en/articles/5322845-runtime-error-could-not-do-actions