### PR TITLE
Show user's access token on the policy server dialog

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/ExperimentView.java
@@ -16,6 +16,7 @@ import io.skymind.pathmind.shared.data.Experiment;
 import io.skymind.pathmind.shared.security.Routes;
 import io.skymind.pathmind.webapp.bus.EventBus;
 import io.skymind.pathmind.webapp.bus.EventBusSubscriber;
+import io.skymind.pathmind.webapp.security.UserService;
 import io.skymind.pathmind.webapp.ui.components.LabelFactory;
 import io.skymind.pathmind.webapp.ui.components.atoms.FloatingCloseButton;
 import io.skymind.pathmind.webapp.ui.components.modelChecker.ModelCheckerService;
@@ -82,6 +83,8 @@ public class ExperimentView extends AbstractExperimentView {
 
     @Autowired
     private ModelCheckerService modelCheckerService;
+    @Autowired
+    private UserService userService;
     @Value("${pathmind.early-stopping.url}")
     private String earlyStoppingUrl;
 
@@ -280,11 +283,11 @@ public class ExperimentView extends AbstractExperimentView {
      * This is overwritten by ShareExperimentView where we only want a subset of buttons.
      */
     protected ExperimentTitleBar createExperimentTitleBar() {
-        return new ExperimentTitleBar(this, this::updateComponents, this::getExperimentLock, getUISupplier(), runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService);
+        return new ExperimentTitleBar(this, this::updateComponents, this::getExperimentLock, getUISupplier(), runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService, userService);
     }
 
     private ExperimentTitleBar createComparisonExperimentTitleBar() {
-        return new ExperimentTitleBar(this, this::updateComparisonComponents, this::getComparisonExperimentLock, getUISupplier(), runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService);
+        return new ExperimentTitleBar(this, this::updateComparisonComponents, this::getComparisonExperimentLock, getUISupplier(), runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService, userService);
     }
 
     private SplitLayout getBottomPanel() {

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/ExperimentTitleBar.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/ExperimentTitleBar.java
@@ -23,6 +23,7 @@ import io.skymind.pathmind.shared.data.Experiment;
 import io.skymind.pathmind.shared.featureflag.Feature;
 import io.skymind.pathmind.shared.featureflag.FeatureManager;
 import io.skymind.pathmind.shared.services.PolicyServerService;
+import io.skymind.pathmind.webapp.security.UserService;
 import io.skymind.pathmind.webapp.ui.components.DownloadModelLink;
 import io.skymind.pathmind.webapp.ui.components.FavoriteStar;
 import io.skymind.pathmind.webapp.ui.components.atoms.ActionDropdown;
@@ -67,6 +68,7 @@ public class ExperimentTitleBar extends HorizontalLayout implements ExperimentCo
     private ExperimentView experimentView;
     private TrainingService trainingService;
     private ModelService modelService;
+    private UserService userService;
     private Runnable updateExperimentViewRunnable;
     private Supplier<Object> getLockSupplier;
     private PolicyDAO policyDAO;
@@ -81,8 +83,15 @@ public class ExperimentTitleBar extends HorizontalLayout implements ExperimentCo
     public ExperimentTitleBar(ExperimentView experimentView, Runnable updateExperimentViewRunnable,
                               Supplier<Object> getLockSupplier, Supplier<Optional<UI>> getUISupplier,
                               RunDAO runDAO, FeatureManager featureManager, PolicyDAO policyDAO, PolicyFileService policyFileService, PolicyServerService policyServerService,
-                              TrainingService trainingService, ModelService modelService) {
-        this(experimentView, updateExperimentViewRunnable, getLockSupplier, getUISupplier, runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService, false);
+                              TrainingService trainingService, ModelService modelService, UserService userService) {
+        this(experimentView, updateExperimentViewRunnable, getLockSupplier, getUISupplier, runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService, userService, false);
+    }
+
+    public ExperimentTitleBar(ExperimentView experimentView, Runnable updateExperimentViewRunnable,
+                              Supplier<Object> getLockSupplier, Supplier<Optional<UI>> getUISupplier,
+                              RunDAO runDAO, FeatureManager featureManager, PolicyDAO policyDAO, PolicyFileService policyFileService, PolicyServerService policyServerService,
+                              TrainingService trainingService, ModelService modelService, boolean isExportPolicyButtonOnly) {
+        this(experimentView, updateExperimentViewRunnable, getLockSupplier, getUISupplier, runDAO, featureManager, policyDAO, policyFileService, policyServerService, trainingService, modelService, null, false);
     }
 
     /**
@@ -91,7 +100,7 @@ public class ExperimentTitleBar extends HorizontalLayout implements ExperimentCo
     public ExperimentTitleBar(ExperimentView experimentView, Runnable updateExperimentViewRunnable,
                               Supplier<Object> getLockSupplier, Supplier<Optional<UI>> getUISupplier,
                               RunDAO runDAO, FeatureManager featureManager, PolicyDAO policyDAO, PolicyFileService policyFileService, PolicyServerService policyServerService,
-                              TrainingService trainingService, ModelService modelService,
+                              TrainingService trainingService, ModelService modelService, UserService userService,
                               boolean isExportPolicyButtonOnly) {
         this.experimentView = experimentView;
         this.getExperimentSupplier = () -> getExperiment();
@@ -99,6 +108,7 @@ public class ExperimentTitleBar extends HorizontalLayout implements ExperimentCo
         this.getLockSupplier = getLockSupplier;
         this.trainingService = trainingService;
         this.modelService = modelService;
+        this.userService = userService;
         this.featureManager = featureManager;
         this.policyDAO = policyDAO;
         this.policyFileService = policyFileService;
@@ -135,7 +145,7 @@ public class ExperimentTitleBar extends HorizontalLayout implements ExperimentCo
         archiveButton = GuiUtils.getPrimaryButton("Archive", click -> ArchiveExperimentAction.archive(experiment, experimentView));
         unarchiveButton = GuiUtils.getPrimaryButton("Unarchive", click -> UnarchiveExperimentAction.unarchive(experimentView, getExperimentSupplier, getLockSupplier));
         exportPolicyButton = new ExportPolicyButton(experimentView.getSegmentIntegrator(), policyFileService, policyDAO, getExperimentSupplier);
-        servePolicyButton = new ServePolicyButton(policyServerService);
+        servePolicyButton = new ServePolicyButton(policyServerService, userService);
         // It is the same for all experiments from the same model so it doesn't have to be updated as long
         // as the user is on the Experiment View (the nav bar only allows navigation to experiments from the same model)
         // If in the future we allow navigation to experiments from other models, then we'll need to update the button accordingly on navigation

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/policy/ServePolicyButton.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/policy/ServePolicyButton.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.progressbar.ProgressBar;
 
 import io.skymind.pathmind.shared.data.Experiment;
 import io.skymind.pathmind.shared.services.PolicyServerService;
+import io.skymind.pathmind.webapp.security.UserService;
 import io.skymind.pathmind.webapp.ui.components.molecules.CopyField;
 import io.skymind.pathmind.webapp.ui.utils.GuiUtils;
 
@@ -22,10 +23,12 @@ public class ServePolicyButton extends Button {
     private Experiment experiment;
     private Dialog dialog;
     private Button closeButton;
+    private UserService userService;
 
-    public ServePolicyButton(PolicyServerService policyServerService) {
+    public ServePolicyButton(PolicyServerService policyServerService, UserService userService) {
         super();
         this.policyServerService = policyServerService;
+        this.userService = userService;
         closeButton = new Button(VaadinIcon.CLOSE_SMALL.create());
         addClickListener(click -> openDialog());
     }
@@ -106,8 +109,16 @@ public class ServePolicyButton extends Button {
                     dialogContent.add(
                             new H3("The Policy is Live"),
                             new Span("The policy is being served at this URL:"),
-                            new CopyField(url, true),
-                            new Paragraph(new Span("Read the docs for more details:"),
+                            new CopyField(url, true)
+                    );
+                    if (userService != null) {
+                        dialogContent.add(
+                            new Span("Your access token:"),
+                            new CopyField(userService.getCurrentUser().getApiKey())
+                        );
+                    }
+                    dialogContent.add(
+                        new Paragraph(new Span("Read the docs for more details:"),
                                     new Html("<br/>"),
                                     docsLink)
                     );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13184582/123624907-c08ef400-d841-11eb-9fbb-9f832eb44af1.png)

Support users will not see the access token because otherwise they'd be seeing their own access token. We currently don't have a way for support users to see a normal user's access token if I understand correctly.
![image](https://user-images.githubusercontent.com/13184582/123625017-e0beb300-d841-11eb-99dd-fbba0cb90c83.png)

Closes #3249 