### PR TITLE
capitalize message attribute

### DIFF
--- a/infra/images/policy-deployer/trigger.py
+++ b/infra/images/policy-deployer/trigger.py
@@ -138,7 +138,7 @@ def process_message(message):
             sns.publish(TopicArn=SNS_UPDATER_TOPIC_ARN,
                         MessageAttributes={
                             'filter': {
-                                'DataType': 'string',
+                                'DataType': 'String',
                                 'StringValue': SNS_UPDATER_SQS_FILTER_ATTR
                             }
                         },


### PR DESCRIPTION
seems DataType attribute should have [capitalized](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.publish) '**String**' value

[repates to #3256 (1.)]