### PR TITLE
Pending dialog animated progress bar

### DIFF
--- a/pathmind-webapp/frontend/src/components/atoms/animated-progress-bar.js
+++ b/pathmind-webapp/frontend/src/components/atoms/animated-progress-bar.js
@@ -2,21 +2,35 @@ import { LitElement, html } from "lit-element";
 
 class AnimatedProgressBar extends LitElement {
   static get properties() {
-      return {
-        duration: {type: Number} // in second
-      }
+    return {
+      duration: {type: Number} // in seconds
+    }
   }
-  constructor() {
-    super();
+  connectedCallback() {
+    super.connectedCallback();
+    this.start = new Date().getTime();
     window.makeProgress = this.makeProgress.bind(this);
+    makeProgress();
+  }
+  firstUpdated() {
+    this.bar = this.renderRoot.querySelector("#bar");
   }
   makeProgress() {
-    if (this.$.bar.value < 100) {
-      this.$.bar.value += 1;
+    if (this.bar == undefined) {
+        requestAnimationFrame(makeProgress);
+        return;
+    }
+    const now = new Date().getTime();
+    if (this.bar.value < 100) {
+      if (now - this.start >= this.duration*1000/100) {
+        this.bar.value += 1;
+        this.start = now;
+      }
+      requestAnimationFrame(makeProgress);
     }
   }
   render() {
-    return html`<vaadin-progress-bar id="bar" min="0" max="100"></vaadin-progress-bar>`;
+    return html`<vaadin-progress-bar id="bar" min="0" max="100" value="0"></vaadin-progress-bar>`;
   }
 }
 

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/atoms/AnimatedProgressBar.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/atoms/AnimatedProgressBar.java
@@ -1,28 +1,20 @@
-package io.skymind.pathmind.webapp.ui.atoms;
+package io.skymind.pathmind.webapp.ui.components.atoms;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.littemplate.LitTemplate;
 import com.vaadin.flow.spring.annotation.SpringComponent;
 import com.vaadin.flow.spring.annotation.UIScope;
-import elemental.json.Json;
-import elemental.json.JsonArray;
-import elemental.json.JsonObject;
 
 @SpringComponent
 @UIScope
 @Tag("animated-progress-bar")
-@JsModule("./src/atoms/animated-progress-bar.js")
+@JsModule("./src/components/atoms/animated-progress-bar.js")
 public class AnimatedProgressBar extends LitTemplate {
 
     public AnimatedProgressBar(int duration) {
+        // duration is in seconds
+        getElement().setProperty("duration", duration);
     }
 
 }

--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/policy/ServePolicyButton.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/experiment/components/policy/ServePolicyButton.java
@@ -9,12 +9,12 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.VaadinIcon;
-import com.vaadin.flow.component.progressbar.ProgressBar;
 
 import io.skymind.pathmind.db.dao.UserDAO;
 import io.skymind.pathmind.shared.data.Experiment;
 import io.skymind.pathmind.shared.data.PathmindUser;
 import io.skymind.pathmind.shared.services.PolicyServerService;
+import io.skymind.pathmind.webapp.ui.components.atoms.AnimatedProgressBar;
 import io.skymind.pathmind.webapp.ui.components.molecules.CopyField;
 import io.skymind.pathmind.webapp.ui.utils.GuiUtils;
 
@@ -133,14 +133,12 @@ public class ServePolicyButton extends Button {
                 case PENDING:
                     // fallthrough
                 default: {
-                    ProgressBar progressBar = new ProgressBar(0, 100);
-                    progressBar.setIndeterminate(true);
                     dialogContent.add(
                             new H3("Deploying Policy Server"),
                             new Paragraph(
                                 "Your policy will be available in about five minutes."
                             ),
-                            progressBar
+                            new AnimatedProgressBar(300)
                     );
                     break;
                 }


### PR DESCRIPTION
At the moment we don't store the timestamp when the user deploys the policy server.
This progress bar starts from 0 when the user opens the popup dialog and will get to 100% after 5 minutes.
If the user closes the popup and reopens it, it will start from 0 again.
![image](https://user-images.githubusercontent.com/13184582/123760975-effe3900-d8f3-11eb-9b13-7beecca5488a.png)

Closes #3268 
