### PR TITLE
Trigger Jenkins PR tests and ignore draft PR's

### DIFF
--- a/.github/workflows/on_dev_pr.yml
+++ b/.github/workflows/on_dev_pr.yml
@@ -1,0 +1,18 @@
+name: Trigger PR test jenkins job
+on:
+  pull_request:
+    branches: 
+      - dev
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    name: Trigger Jenkins
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger PR tests
+      uses: appleboy/jenkins-action@master
+      with:
+        url: "https://jenkins.dev.devpathmind.com"
+        user: "admin"
+        token: ${{ secrets.JENKINS_TOKEN }}
+        job: "Test_PRs"


### PR DESCRIPTION
Hi, @slinlee This is related to https://github.com/SkymindIO/pathmind-webapp/issues/3115, I am really sorry I have missed it.

If you think is ok I can do some tests and disable the webhook and trigger Jenkins only from here.