### PR TITLE
Give metric charts min width to avoid shrinking due to long metric name

### DIFF
--- a/pathmind-webapp/frontend/styles/views/experiment-view.css
+++ b/pathmind-webapp/frontend/styles/views/experiment-view.css
@@ -189,6 +189,7 @@
 .experiment-view .histograms-wrapper {
     flex: 1 0 0;
     width: auto !important;
+    min-width: 5.625rem;
     line-height: 2rem;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13184582/126759424-34e2850d-d112-415c-98d2-7c51473db23d.png)

Closes #3352 