### PR TITLE
Dev-3410 keep boolean value as lower case in Simulation Parameter DB

### DIFF
--- a/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/SimulationParameterRepository.java
+++ b/pathmind-database/src/main/java/io/skymind/pathmind/db/dao/SimulationParameterRepository.java
@@ -1,5 +1,6 @@
 package io.skymind.pathmind.db.dao;
 
+import io.skymind.pathmind.shared.constants.ParamType;
 import io.skymind.pathmind.shared.data.SimulationParameter;
 import org.jooq.DSLContext;
 import org.jooq.Query;
@@ -11,6 +12,11 @@ import static io.skymind.pathmind.db.jooq.Tables.SIMULATION_PARAMETER;
 
 public class SimulationParameterRepository {
     protected static void insertOrUpdateSimulationParameter(DSLContext ctx, List<SimulationParameter> simParams) {
+        simParams.forEach(p -> {
+            if (p.getType() == ParamType.BOOLEAN.getValue()) {
+                p.setValue(String.valueOf(Boolean.parseBoolean(p.getValue())));
+            }
+        });
         final List<Query> saveQueries = simParams.stream()
             .map(param ->
                 ctx.insertInto(SIMULATION_PARAMETER)

--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/data/SimulationParameter.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/data/SimulationParameter.java
@@ -29,6 +29,12 @@ public class SimulationParameter extends Data implements DeepCloneableInterface<
     }
 
     public String getWrappedValue() {
-        return type == ParamType.STRING.getValue() ? "\"" + value + "\"" : value;
+        if (type == ParamType.STRING.getValue())
+            return "\"" + value + "\"";
+
+        if (type == ParamType.BOOLEAN.getValue())
+            return String.valueOf(Boolean.parseBoolean(value));
+
+        return value;
     }
 }


### PR DESCRIPTION
if we change the boolean type of simulation parameter, it will be saved as upper cases.
we need to keep it as lower cases for java convention.