### PR TITLE
Fix copy share link button for firefox

### DIFF
--- a/pathmind-webapp/frontend/src/components/molecules/copy-field.js
+++ b/pathmind-webapp/frontend/src/components/molecules/copy-field.js
@@ -131,7 +131,8 @@ class CopyField extends PolymerElement {
         const checkmarkIcon = copyButton.querySelector("span:last-child");
         const range = document.createRange();
         range.selectNode(this.$.textToCopy);
-        const select = this.shadowRoot.getSelection();
+        const select = navigator.userAgent.toLowerCase().indexOf('firefox') > -1 
+                ? window.getSelection() : this.shadowRoot.getSelection();
         select.removeAllRanges();
         select.addRange(range);
         document.execCommand("copy");


### PR DESCRIPTION
Please test it on Firefox.

Closes #3467 