### PR TITLE
Fix observations get highlighted again after user exited comparison mode then switched to another experiment

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/observations/ObservationsViewOnlyPanel.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/observations/ObservationsViewOnlyPanel.java
@@ -94,6 +94,7 @@ public class ObservationsViewOnlyPanel extends VerticalLayout implements Experim
     }
 
     public void unhighlight() {
+        this.comparisonModeTheOtherSelectedObservations = null;
         checkboxList.forEach(checkbox -> checkbox.removeClassName(highlightClassName));
     }
 


### PR DESCRIPTION
Closes #3504 