### PR TITLE
Navigate to previous page after enabling reward terms feature

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/settings/BetaFeatureSettingsViewContent.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/views/settings/BetaFeatureSettingsViewContent.java
@@ -52,6 +52,7 @@ public class BetaFeatureSettingsViewContent extends LitTemplate {
             getElement().setProperty("withRewardTerms", newRewardTermsOn);
             if (newRewardTermsOn) {
                 segmentIntegrator.enabledRewardTermsToggle();
+                getUI().ifPresent(ui -> ui.getPage().getHistory().back());
             } else {
                 segmentIntegrator.disabledRewardTermsToggle();
             }


### PR DESCRIPTION
Essentially this is acting like the browser's "Back" button.
If the user gets to the Beta Feature Settings page from the side menu, they'll be directed back to whichever page (e.g. Projects, New Experiment, Settings, etc...) they were previously on.

Closes #3556 