### PR TITLE
API: do not call MA, when upload Pathmind simulation

### DIFF
--- a/pathmind-services/src/main/java/io/skymind/pathmind/services/experiment/ExperimentService.java
+++ b/pathmind-services/src/main/java/io/skymind/pathmind/services/experiment/ExperimentService.java
@@ -125,14 +125,13 @@ public class ExperimentService {
                 String reqId = "project_" + model.getProjectId();
                 File tempFile = File.createTempFile("pathmind", UUID.randomUUID().toString());
                 FileUtils.writeByteArrayToFile(tempFile, model.getFile());
-                HyperparametersDTO analysisResult =
-                        projectFileCheckService.getClient().analyze(tempFile, type, reqId, environment);
-                if (StringUtils.isNotEmpty(analysisResult.getFailedSteps())) {
-                    throw new ModelCheckException(analysisResult.getFailedSteps());
-                }
                 if (isPathmindSimulation) {
                     model.setModelType(ModelType.PM_SINGLE.getValue());
                 } else {
+                    HyperparametersDTO analysisResult = projectFileCheckService.getClient().analyze(tempFile, type, reqId, environment);
+                    if (StringUtils.isNotEmpty(analysisResult.getFailedSteps())) {
+                        throw new ModelCheckException(analysisResult.getFailedSteps());
+                    }
                     model.setModelType(ModelType.fromName(analysisResult.getMode()).getValue());
                 }
                 model.setPackageName(String.join(";", environment, obsSelection, rewFctName));


### PR DESCRIPTION
```
curl -i -XPOST -H "X-PM-API-TOKEN: ab2c411d-efe2-4e3b-b8b0-09747809e997" \
-F 'file=@/home/malex/Downloads/python_examples.zip' \
-F 'env=exaples.mouse.single_agent_mouse_env.MouseAndCheese' \
-F 'isPathmindSimulation=true' \
http://localhost:8081/py/upload
```

`-F 'isPathmindSimulation=true' `
is important 


