### PR TITLE
Update files for MA for staging too

### DIFF
--- a/infra/scripts/canary_deploy.sh
+++ b/infra/scripts/canary_deploy.sh
@@ -59,7 +59,4 @@ kubectl create configmap canary \
 	--dry-run | kubectl replace -f -
 
 #make sure the libraries for model analyzer are ready
-if [ "${environment}" != "staging" ]
-then
-	curl -X PUT -u "${apiuser}:${apipassword}" https://${subdomain}${domain}/api/MAlib/${environment}
-fi
+curl -X PUT -u "${apiuser}:${apipassword}" https://${subdomain}${domain}/api/MAlib/${environment}


### PR DESCRIPTION
The MA static files S3 buckets haven't been updating. This might be because we haven't bumped the version numbers. This PR is just an adjustment to also update the files for staging too.

This triggers the function here:
https://github.com/SkymindIO/pathmind-webapp/blob/dev/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/api/VersionController.java#L111-L142