### PR TITLE
Dev-3585 avoid keep adding metrics label for Py model

### DIFF
--- a/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/rewardVariables/RewardVariablesTable.java
+++ b/pathmind-webapp/src/main/java/io/skymind/pathmind/webapp/ui/components/rewardVariables/RewardVariablesTable.java
@@ -65,7 +65,7 @@ public class RewardVariablesTable extends VerticalLayout implements ExperimentCo
     }
 
     public void setRewardVariables(List<RewardVariable> rewardVariables) {
-        if (rewardVariableNameFields.isEmpty()) {
+        if (rewardVariableNameFields.isEmpty() && container.getComponentCount() == 0) {
             HorizontalLayout headerRow = WrapperUtils.wrapWidthFullHorizontal(new Span("Metric"), new Span("Goal"));
             headerRow.addClassName("header-row");
             GuiUtils.removeMarginsPaddingAndSpacing(headerRow);


### PR DESCRIPTION
fix: https://github.com/SkymindIO/pathmind-webapp/issues/3585

the reason for this issue is py model doesn't have metrics reward variables and we add `metrics` label if reward variables whenever updating training progress.
