### PR TITLE
Bump NativeRL version to 1.8.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def buildDockerImageMA(image_name, dockerfile, basedir, docker_tag) {
         --build-arg S3BUCKET='${docker_tag}-training-static-files.pathmind.com' \
         --build-arg AWS_ACCESS_KEY_ID=`kubectl get secret awsaccesskey -o=jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 --decode` \
         --build-arg AWS_SECRET_ACCESS_KEY=`kubectl get secret awssecretaccesskey -o=jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 --decode` ${basedir}/ \
-        --build-arg NATIVERL_FOLDER='nativerl/1_8_0'
+        --build-arg NATIVERL_FOLDER='nativerl/1_8_1'
     """
 }
 

--- a/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
+++ b/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java
@@ -391,6 +391,7 @@ public class AWSExecutionProvider implements ExecutionProvider {
             case VERSION_1_7_1:
             case VERSION_1_7_2:
             case VERSION_1_8_0:
+            case VERSION_1_8_1:
                 nativerlVersion.fileNames().forEach(filename -> {
                     instructions.addAll(Arrays.asList(
                         // Setup NativeRL

--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/environment/ExecutionEnvironmentManager.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/environment/ExecutionEnvironmentManager.java
@@ -23,7 +23,7 @@ public class ExecutionEnvironmentManager {
                 false,
                 AnyLogic.VERSION_8_7_7,
                 PathmindHelper.VERSION_1_7_0,
-                NativeRL.VERSION_1_8_0,
+                NativeRL.VERSION_1_8_1,
                 JDK.VERSION_8_222,
                 Conda.VERSION_1_3_0,
                 EC2InstanceType.IT_36CPU_72GB,

--- a/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/versions/NativeRL.java
+++ b/pathmind-shared/src/main/java/io/skymind/pathmind/shared/services/training/versions/NativeRL.java
@@ -21,7 +21,9 @@ public enum NativeRL implements VersionEnum {
     VERSION_1_7_0,
     VERSION_1_7_1,
     VERSION_1_7_2,
-    VERSION_1_8_0;
+    VERSION_1_8_0,
+    VERSION_1_8_1;
+
 
     private static final String baseFileName = "nativerl-%s-SNAPSHOT-bin.zip";
     public static final String simpleFileName = "nativerl-bin.zip";


### PR DESCRIPTION
- Bump version of nativeRL to 1.8.0
- Add new required param for building Model Analyzer
- Add NativeRL 1.8.1 support
