### PR TITLE
Hotfix - Don't copy ma files on S3 anymore

### DIFF
--- a/infra/scripts/canary_deploy.sh
+++ b/infra/scripts/canary_deploy.sh
@@ -58,8 +58,3 @@ kubectl create configmap canary \
 	-o yaml \
 	--dry-run | kubectl replace -f -
 
-#make sure the libraries for model analyzer are ready
-if [ "${environment}" != "staging" ]
-then
-	curl -X PUT -u "${apiuser}:${apipassword}" https://${subdomain}${domain}/api/MAlib/${environment}
-fi


### PR DESCRIPTION
The deploy would copy over the files used on the old MA S3 resources bucket. I need it to use the old files since I'm reverting the release from today.

- Don't copy ma files on S3 anymore
