### PR TITLE
Merge Hotfix from prod - Don't copy ma files on S3 anymore (#3613)

### DIFF
--- a/infra/scripts/canary_deploy.sh
+++ b/infra/scripts/canary_deploy.sh
@@ -57,6 +57,3 @@ kubectl create configmap canary \
 	-n ${namespace} \
 	-o yaml \
 	--dry-run | kubectl replace -f -
-
-#make sure the libraries for model analyzer are ready
-curl -X PUT -u "${apiuser}:${apipassword}" https://${subdomain}${domain}/api/MAlib/${environment}


### PR DESCRIPTION
The deploy would copy over the files used on the old MA S3 resources bucket. I need it to use the old files since I'm reverting the release from today.

Don't copy ma files on S3 anymore
