### PR TITLE
Fix copy function for Safari

### DIFF
--- a/pathmind-webapp/frontend/src/components/molecules/copy-field.ts
+++ b/pathmind-webapp/frontend/src/components/molecules/copy-field.ts
@@ -125,8 +125,7 @@ class CopyField extends LitElement {
         const checkmarkIcon = copyButton.querySelector("span:last-child");
         const range = document.createRange();
         range.selectNode(this.shadowRoot.getElementById("textToCopy"));
-        const select = navigator.userAgent.toLowerCase().indexOf('firefox') > -1 
-                ? window.getSelection() : (this.shadowRoot as any).getSelection();
+        const select = window.getSelection();
         select.removeAllRanges();
         select.addRange(range);
         document.execCommand("copy");


### PR DESCRIPTION
Tested on Chrome 94.0.4606.81 on Windows, Firefox 93.0 on Windows, and Safari 14.1.2 on Big Sur (on BrowserStack).

Closes #3647 